### PR TITLE
Dataless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0
+* Add support for custom type specific reactors, eliminating the need for data/config (which the server flattens anyway)
+
 # 1.2.1
 * Fix serialization to never include contexts
 * Fix onResult not to be called if there was no context response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/reactors.js
+++ b/src/reactors.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import * as F from 'futil-js'
 
 // TODO check type, etc
 let hasContext = node => node.context
@@ -57,6 +58,9 @@ export let StandardReactors = {
   mutate: (parent, node, event, types) =>
     _.flow(
       _.keys,
+      // assumes reactors are { field: reactor, ...}
+      _.map(F.aliasIn(_.getOr({}, `${node.type}.reactors`, types))),
+      _.uniq,
       _.flatMap(x => Reactor(x)(parent, node, event, types)),
       _.compact,
       _.uniq

--- a/test/index.js
+++ b/test/index.js
@@ -424,40 +424,45 @@ describe('lib', () => {
     let filterUpdated = sinon.spy()
     let onResult = _.cond([
       [_.isEqual(['root', 'results']), resultsUpdated],
-      [_.isEqual(['root', 'filter']), filterUpdated]
+      [_.isEqual(['root', 'filter']), filterUpdated],
     ])
-    
-    let Tree = lib.ContextTree({
-      key: 'root',
-      join: 'and',
-      children: [
-        {
-          key: 'filter',
-          type: 'testType',
+
+    let Tree = lib.ContextTree(
+      {
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'filter',
+            type: 'testType',
+          },
+          {
+            key: 'results',
+            type: 'results',
+          },
+        ],
+      },
+      service,
+      {
+        testType: {
+          reactors: {
+            value: 'others',
+            optionType: 'only',
+          },
         },
-        {
-          key: 'results',
-          type: 'results'
-        },
-      ],
-    }, service, {
-      testType: {
-        reactors: {
-          value: 'others',
-          optionType: 'only'
-        }
+      },
+      {
+        onResult,
       }
-    }, {
-      onResult
-    })
+    )
     await Tree.mutate(['root', 'filter'], {
-      value: 'a'
+      value: 'a',
     })
     expect(service).to.have.callCount(1)
     expect(resultsUpdated).to.have.callCount(1)
     expect(filterUpdated).to.have.callCount(0)
     await Tree.mutate(['root', 'filter'], {
-      optionType: 2
+      optionType: 2,
     })
     expect(service).to.have.callCount(2)
     expect(resultsUpdated).to.have.callCount(1)


### PR DESCRIPTION
* Add support for custom type specific reactors, eliminating the need for data/config (which the server flattens anyway)
