### PR TITLE
New api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.0.0
+* Add decoded `path` to each node
+* **Breaking change** Simplified initial api from `(tree, service, types, config)` to moving service and types into config as the first param and currying.
+
+### Migration Guide
+Replace every call like this: `ContextTree(tree, service, types, {...config})`
+with a call like this: `ContextTree({service, types, ...config}, tree)`
+
 # 1.3.0
 * Add support for custom type specific reactors, eliminating the need for data/config (which the server flattens anyway)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture-client#readme",
   "dependencies": {
-    "futil-js": "^1.42.0",
+    "futil-js": "^1.42.1",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,7 +6,7 @@ export default ({ getNode, flat, dispatch, snapshot, extend }) => ({
   async add(parentPath, value) {
     let target = getNode(parentPath)
     let path = [...parentPath, value.key]
-    extend(value, {path})
+    extend(value, { path })
     target.children.push(value)
     // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
     flat[encode(path)] = target.children[target.children.length - 1]

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,6 +6,7 @@ export default ({ getNode, flat, dispatch, snapshot, extend }) => ({
   async add(parentPath, value) {
     let target = getNode(parentPath)
     let path = [...parentPath, value.key]
+    extend(value, {path})
     target.children.push(value)
     // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
     flat[encode(path)] = target.children[target.children.length - 1]

--- a/src/index.js
+++ b/src/index.js
@@ -28,21 +28,9 @@ let shouldDropUpdate = (result, target) =>
   result.lastUpdateTime &&
   target.lastUpdateTime > result.lastUpdateTime
 
-export let ContextTree = _.curry((
-  {
-    service = () => {
-      throw new Error('No update service provided!')
-    },
-    types = exampleTypes,
-    debounce = 1,
-    onResult = _.noop,
-    allowBlank,
-    debug, //= true
-    extend = F.extendOn,
-    snapshot = _.cloneDeep,
-  },
-  tree
-) => {
+export let ContextTree = _.curry(({ service = () => {
+    throw new Error('No update service provided!')
+  }, types = exampleTypes, debounce = 1, onResult = _.noop, allowBlank, debug, extend = F.extendOn, snapshot = _.cloneDeep }, tree) => { //= true
   let log = x => debug && console.info(x)
   let flat = flattenTree(tree)
   F.eachIndexed((node, path) => {

--- a/src/index.js
+++ b/src/index.js
@@ -28,20 +28,20 @@ let shouldDropUpdate = (result, target) =>
   result.lastUpdateTime &&
   target.lastUpdateTime > result.lastUpdateTime
 
-export let ContextTree = (
-  tree,
-  service = () => {
-    throw new Error('No update service provided!')
-  },
-  types = exampleTypes,
+export let ContextTree = _.curry((
   {
-    snapshot = _.cloneDeep,
-    extend = F.extendOn,
+    service = () => {
+      throw new Error('No update service provided!')
+    },
+    types = exampleTypes,
     debounce = 1,
-    allowBlank = false,
     onResult = _.noop,
+    allowBlank,
     debug, //= true
-  } = {}
+    extend = F.extendOn,
+    snapshot = _.cloneDeep,
+  },
+  tree
 ) => {
   let log = x => debug && console.info(x)
   let flat = flattenTree(tree)
@@ -84,5 +84,5 @@ export let ContextTree = (
     dispatch,
     serialize: () => serialize(snapshot(tree), {}),
   }
-}
+})
 export default ContextTree

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,9 @@ export let ContextTree = _.curry((
 ) => {
   let log = x => debug && console.info(x)
   let flat = flattenTree(tree)
+  F.eachIndexed((node, path) => {
+    node.path = decode(path)
+  }, flat)
   let getNode = path => flat[encode(path)]
 
   // Event Handling

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,8 @@ let shouldDropUpdate = (result, target) =>
 
 export let ContextTree = _.curry(({ service = () => {
     throw new Error('No update service provided!')
-  }, types = exampleTypes, debounce = 1, onResult = _.noop, allowBlank, debug, extend = F.extendOn, snapshot = _.cloneDeep }, tree) => { //= true
+  }, types = exampleTypes, debounce = 1, onResult = _.noop, allowBlank, debug, extend = F.extendOn, snapshot = _.cloneDeep }, tree) => {
+  //= true
   let log = x => debug && console.info(x)
   let flat = flattenTree(tree)
   F.eachIndexed((node, path) => {

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('lib', () => {
       ],
     }
     let service = sinon.spy(mockService())
-    let Tree = lib.ContextTree(tree, service)
+    let Tree = lib.ContextTree({service}, tree)
     it('should generally mutate', async () => {
       await Tree.mutate(['root', 'filter'], {
         data: {
@@ -224,7 +224,7 @@ describe('lib', () => {
     it('should handle groups being paused')
   })
   it('should throw if no service is provided', async () => {
-    let Tree = lib.ContextTree({
+    let Tree = lib.ContextTree({}, {
       key: 'root',
       children: [
         {
@@ -248,7 +248,7 @@ describe('lib', () => {
     throw Error('Should have thrown')
   })
   // it('should ignore searches where everything is filterOnly', () => {
-  //   let Tree = lib.contextTree({
+  //   let Tree = lib.contextTree({}, {
   //     key: 'root',
   //     children: [{
   //       key:'filter'
@@ -261,6 +261,7 @@ describe('lib', () => {
   it('should work', async () => {
     let service = sinon.spy(mockService())
     let Tree = lib.ContextTree(
+      {service},
       {
         key: 'root',
         join: 'and',
@@ -320,8 +321,7 @@ describe('lib', () => {
             ],
           },
         ],
-      },
-      service
+      }
     )
 
     await Tree.mutate(['root', 'criteria', 'mainQuery'], {
@@ -400,9 +400,10 @@ describe('lib', () => {
     let spy = sinon.spy()
     // Just call the spy for `results`
     let onResult = path => _.isEqual(path, ['root', 'results']) && spy()
-    let Tree = lib.ContextTree(tree, service, undefined, {
+    let Tree = lib.ContextTree({
+      service,
       onResult,
-    })
+    }, tree)
     let step1 = Tree.mutate(['root', 'filter'], {
       data: {
         values: ['a'],
@@ -427,8 +428,18 @@ describe('lib', () => {
       [_.isEqual(['root', 'filter']), filterUpdated],
     ])
 
-    let Tree = lib.ContextTree(
-      {
+    let Tree = lib.ContextTree({
+      types: {
+        testType: {
+          reactors: {
+            value: 'others',
+            optionType: 'only',
+          },
+        },
+      },
+      service,
+      onResult,
+    }, {
         key: 'root',
         join: 'and',
         children: [
@@ -441,19 +452,8 @@ describe('lib', () => {
             type: 'results',
           },
         ],
-      },
-      service,
-      {
-        testType: {
-          reactors: {
-            value: 'others',
-            optionType: 'only',
-          },
-        },
-      },
-      {
-        onResult,
       }
+      
     )
     await Tree.mutate(['root', 'filter'], {
       value: 'a',

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('lib', () => {
       ],
     }
     let service = sinon.spy(mockService())
-    let Tree = lib.ContextTree({service}, tree)
+    let Tree = lib.ContextTree({ service }, tree)
     it('should generally mutate', async () => {
       await Tree.mutate(['root', 'filter'], {
         data: {
@@ -224,17 +224,20 @@ describe('lib', () => {
     it('should handle groups being paused')
   })
   it('should throw if no service is provided', async () => {
-    let Tree = lib.ContextTree({}, {
-      key: 'root',
-      children: [
-        {
-          key: 'filter',
-        },
-        {
-          key: 'results',
-        },
-      ],
-    })
+    let Tree = lib.ContextTree(
+      {},
+      {
+        key: 'root',
+        children: [
+          {
+            key: 'filter',
+          },
+          {
+            key: 'results',
+          },
+        ],
+      }
+    )
     try {
       await Tree.mutate(['root', 'filter'], {
         data: {
@@ -261,7 +264,7 @@ describe('lib', () => {
   it('should work', async () => {
     let service = sinon.spy(mockService())
     let Tree = lib.ContextTree(
-      {service},
+      { service },
       {
         key: 'root',
         join: 'and',
@@ -400,10 +403,13 @@ describe('lib', () => {
     let spy = sinon.spy()
     // Just call the spy for `results`
     let onResult = path => _.isEqual(path, ['root', 'results']) && spy()
-    let Tree = lib.ContextTree({
-      service,
-      onResult,
-    }, tree)
+    let Tree = lib.ContextTree(
+      {
+        service,
+        onResult,
+      },
+      tree
+    )
     let step1 = Tree.mutate(['root', 'filter'], {
       data: {
         values: ['a'],
@@ -428,18 +434,20 @@ describe('lib', () => {
       [_.isEqual(['root', 'filter']), filterUpdated],
     ])
 
-    let Tree = lib.ContextTree({
-      types: {
-        testType: {
-          reactors: {
-            value: 'others',
-            optionType: 'only',
+    let Tree = lib.ContextTree(
+      {
+        types: {
+          testType: {
+            reactors: {
+              value: 'others',
+              optionType: 'only',
+            },
           },
         },
+        service,
+        onResult,
       },
-      service,
-      onResult,
-    }, {
+      {
         key: 'root',
         join: 'and',
         children: [
@@ -453,7 +461,6 @@ describe('lib', () => {
           },
         ],
       }
-      
     )
     await Tree.mutate(['root', 'filter'], {
       value: 'a',

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -10,10 +10,11 @@ chai.use(sinonChai)
 
 let treeUtils = Tree
 let ContextTreeMobx = (tree, service) =>
-  lib.ContextTree(tree, service, undefined, {
+  lib.ContextTree({
+    service,
     snapshot: toJS,
     extend: extendObservable,
-  })
+  }, tree)
 
 describe('usage with mobx should generally work', () => {
   // TODO: make these generally self contained - some rely on previous test runs

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -10,11 +10,14 @@ chai.use(sinonChai)
 
 let treeUtils = Tree
 let ContextTreeMobx = (tree, service) =>
-  lib.ContextTree({
-    service,
-    snapshot: toJS,
-    extend: extendObservable,
-  }, tree)
+  lib.ContextTree(
+    {
+      service,
+      snapshot: toJS,
+      extend: extendObservable,
+    },
+    tree
+  )
 
 describe('usage with mobx should generally work', () => {
   // TODO: make these generally self contained - some rely on previous test runs
@@ -87,7 +90,7 @@ describe('usage with mobx should generally work', () => {
         },
         {
           key: 'results',
-          type:'results',
+          type: 'results',
           lastUpdateTime: now,
         },
       ],
@@ -101,7 +104,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: ['a'],
       },
-      path: ['root', 'filter']
+      path: ['root', 'filter'],
     })
     // should update contexts
     expect(Tree.getNode(['root', 'results']).updating).to.be.false
@@ -148,7 +151,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: 'asdf',
       },
-      path: ['root', 'newFilterWithValue']
+      path: ['root', 'newFilterWithValue'],
     })
     disposer()
   })
@@ -192,7 +195,7 @@ describe('usage with mobx should generally work', () => {
     ).to.deep.equal({
       key: 'newEmptyFilter',
       context: {},
-      path: ['root', 'newEmptyFilter']
+      path: ['root', 'newEmptyFilter'],
     })
     expect(
       _.omit(
@@ -205,7 +208,7 @@ describe('usage with mobx should generally work', () => {
       hasValue: false,
       updating: true,
       markedForUpdate: false,
-      path: ['root', 'newEmptyFilter']
+      path: ['root', 'newEmptyFilter'],
     })
 
     expect(
@@ -224,7 +227,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: 'asdf',
       },
-      path: ['root', 'newFilterWithValueForRemoveTest']
+      path: ['root', 'newFilterWithValueForRemoveTest'],
     })
     expect(
       treeUtils.lookup(
@@ -237,7 +240,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: 'asdf',
       },
-      path: ['root', 'newFilterWithValueForRemoveTest']
+      path: ['root', 'newFilterWithValueForRemoveTest'],
     })
     disposer()
   })

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -99,6 +99,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: ['a'],
       },
+      path: ['root', 'filter']
     })
     // should update contexts
     expect(Tree.getNode(['root', 'results']).updating).to.be.false
@@ -145,6 +146,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: 'asdf',
       },
+      path: ['root', 'newFilterWithValue']
     })
     disposer()
   })
@@ -188,6 +190,7 @@ describe('usage with mobx should generally work', () => {
     ).to.deep.equal({
       key: 'newEmptyFilter',
       context: {},
+      path: ['root', 'newEmptyFilter']
     })
     expect(
       _.omit(
@@ -200,6 +203,7 @@ describe('usage with mobx should generally work', () => {
       hasValue: false,
       updating: true,
       markedForUpdate: false,
+      path: ['root', 'newEmptyFilter']
     })
 
     expect(
@@ -218,6 +222,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: 'asdf',
       },
+      path: ['root', 'newFilterWithValueForRemoveTest']
     })
     expect(
       treeUtils.lookup(
@@ -230,6 +235,7 @@ describe('usage with mobx should generally work', () => {
       data: {
         values: 'asdf',
       },
+      path: ['root', 'newFilterWithValueForRemoveTest']
     })
     disposer()
   })

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -30,6 +30,7 @@ describe('usage with mobx should generally work', () => {
       },
       {
         key: 'results',
+        type: 'results',
         context: {
           results: null,
         },
@@ -86,6 +87,7 @@ describe('usage with mobx should generally work', () => {
         },
         {
           key: 'results',
+          type:'results',
           lastUpdateTime: now,
         },
       ],


### PR DESCRIPTION
* Add decoded `path` to each node
* **Breaking change** Simplified initial api from `(tree, service, types, config)` to moving service and types into config as the first param and currying.

### Migration Guide
Replace every call like this: `ContextTree(tree, service, types, {...config})` with a call like this: `ContextTree({service, types, ...config}, tree)`