### PR TITLE
The mergeOn at processResponse fails to update Mobx Arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,9 +78,9 @@ export let ContextTree = _.curry(
           onResult(decode(path), node, target)
           // mergeOn will not replace Mobx Arrays
           // F.mergeOn(target, responseNode)
-          let onlyKey = _.head(_.keys(responseNode))                                                                                                                                                                                      
-          if (!target[onlyKey]) target[onlyKey] = {} 
-          _.mapKeys(key => { 
+          let onlyKey = _.head(_.keys(responseNode))
+          if (!target[onlyKey]) target[onlyKey] = {}
+          _.mapKeys(key => {
             target[onlyKey][key] = responseNode[onlyKey][key]
           }, responseNode[onlyKey])
           target.updating = false

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,13 @@ export let ContextTree = _.curry(
         let responseNode = _.pick(['context', 'error'], node)
         if (target && !_.isEmpty(responseNode) && !isStale(node, target)) {
           onResult(decode(path), node, target)
-          F.mergeOn(target, responseNode)
+          // mergeOn will not replace Mobx Arrays
+          // F.mergeOn(target, responseNode)
+          let onlyKey = _.head(_.keys(responseNode))                                                                                                                                                                                      
+          if (!target[onlyKey]) target[onlyKey] = {} 
+          _.mapKeys(key => { 
+            target[onlyKey][key] = responseNode[onlyKey][key]
+          }, responseNode[onlyKey])
           target.updating = false
         }
       }, flattenTree(data))


### PR DESCRIPTION
Mobx Arrays experience the change property per property, but never removes the ending values, so the array remains at the original length.

This might be a needed fix in mergeOn instead, or it might be coded in a prettier way, however it's best, I'm just pointing at an issue.