### PR TITLE
v2.0.4 processResponse should not break if the service returns an empty object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+lib
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 2.0.3
+﻿# 2.0.4
+* Making sure that we don't break if the service returns an empty
+  value.
+
+# 2.0.3
 * Fixed bug with nested custom reactors.
 * Fixdd bug with the mergeOn used by processResponse that was causing
   mobx arrays to mix old and new values instead of replacing them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export let ContextTree = _.curry(
       prepForUpdate(tree)
       processResponse(await service(dto, now))
     })
-    let processResponse = ({ data, error }) => {
+    let processResponse = ({ data, error } = {}) => {
       F.eachIndexed((node, path) => {
         let target = flat[path]
         let responseNode = _.pick(['context', 'error'], node)

--- a/test/service.js
+++ b/test/service.js
@@ -1,0 +1,40 @@
+import * as F from 'futil-js'
+import chai from 'chai'
+import sinonChai from 'sinon-chai'
+import * as lib from '../src'
+import Promise from 'bluebird'
+const expect = chai.expect
+chai.use(sinonChai)
+
+describe('services', () => {
+  it('should not throw if the service is too busy to answer', async () => {
+    let tree = {
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'filter',
+        },
+        {
+          key: 'results',
+          type: 'results',
+        },
+      ],
+    }
+    let service = F.aspects.command()(async () => {
+      await Promise.delay(10)
+      return { data: {} }
+    })
+    let Tree = lib.ContextTree({ service }, tree)
+    let errors = []
+    for (let i = 0; i < 10; i++) {
+      Tree.mutate(['root', 'filter'], {
+        data: {
+          values: ['a'],
+        },
+      }).catch(F.pushOn(errors))
+      await Promise.delay(1)
+    }
+    expect(errors).to.be.empty
+  })
+})


### PR DESCRIPTION
With a test using futil's aspects.