### PR TITLE
Exporting the exampleTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.0.5
+# 2.0.6
+* Exposed exampleTypes
+
+# 2.0.5
 * Removed the default group reactor that listened to children changes.
 
 # 2.0.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import actions from './actions'
 import serialize from './serialize'
 import { markForUpdate, markLastUpdate, prepForUpdate } from './traversals'
 import { runTypeFunction } from './types'
-import exampleTypes from './exampleTypes'
+import exampleTypes as _exampleTypes from './exampleTypes'
 
 let mergeWith = _.mergeWith.convert({ immutable: false })
 
@@ -38,7 +38,7 @@ let defaultService = () => {
   throw new Error('No update service provided!')
 }
 
-export exampleTypes
+export let exampleTypes = _exampleTypes
 
 export let ContextTree = _.curry(
   (

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import actions from './actions'
 import serialize from './serialize'
 import { markForUpdate, markLastUpdate, prepForUpdate } from './traversals'
 import { runTypeFunction } from './types'
-import exampleTypes as _exampleTypes from './exampleTypes'
+import Types from './exampleTypes'
 
 let mergeWith = _.mergeWith.convert({ immutable: false })
 
@@ -38,13 +38,13 @@ let defaultService = () => {
   throw new Error('No update service provided!')
 }
 
-export let exampleTypes = _exampleTypes
+export let exampleTypes = Types
 
 export let ContextTree = _.curry(
   (
     {
       service = defaultService,
-      types = exampleTypes,
+      types = Types,
       debounce = 1,
       onResult = _.noop,
       allowBlank,

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,9 @@ let stampPaths = F.eachIndexed((node, path) => {
 let defaultService = () => {
   throw new Error('No update service provided!')
 }
+
+export exampleTypes
+
 export let ContextTree = _.curry(
   (
     {


### PR DESCRIPTION
Code that relies on webpack doesn't have access to the exampleTypes unless we export them.