### PR TITLE
Update exampleTypes.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.1.0
+# 2.1.1
+* Fix facet reactor for `optionsFilter` (was incorrectly named `filter`)
+
+# 2.1.0
 * Implemented a refresh action.
 
 # 2.0.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -10,7 +10,7 @@ export default {
       values: 'others',
       mode: 'others',
       size: 'self',
-      filter: 'self',
+      optionsFilter: 'self',
     },
   },
   text: {


### PR DESCRIPTION
* Fix facet reactor for `optionsFilter` (was incorrectly named `filter`)