### PR TITLE
[2.7] Expose `mockService` as a top level export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+# 2.7.0
+* Expose `mockService` as a top level default
+
 # 2.6.1
-* Ensure mockService is accessible from `src`
+* Ensure `mockService` is accessible from `src`
 
 # 2.6.0
 * Expose `addActions` to enable extending the client with new actions that have the same access levels as first party ones.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.7.0
-* Expose `mockService` as a top level default
+* Expose `mockService` as a top level export
 
 # 2.6.1
 * Ensure `mockService` is accessible from `src`

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ import { utilName } from 'contexture-client'
 | `hasContext` | An internal utility that determines if a node has a context. Used primarily in custom reactors to help figure out if a node needs updating. |
 | `hasValue` | An internal utility that checks if a node has a value and isn't in an error state. Used primarily in custom reactors to help figure out if other nodes would be affected by an event. |
 | `exampleTypes` | A set of example types. This will likely be split out in a future version to its own repo. |
+| `mockService` | Useful for mocking services during testing. Takes a config object of logInput, logOutput, and a mocks function which will should return results for a node as input (defaults to fixed results by type) and returns a function for use as a `service` for a contexture-client instance. |
 
 ### Extending the Client
 The client can be enhanced with new types, actions, and reactors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { runTypeFunction } from './types'
 import { initNode, hasContext, hasValue } from './node'
 import exampleTypes from './exampleTypes'
 import lens from './lens'
+import mockService from './mockService'
 
 let mergeWith = _.mergeWith.convert({ immutable: false })
 
@@ -30,7 +31,7 @@ let defaultService = () => {
 }
 
 // Export useful utils which might be needed for extending the core externally
-export { Tree, encode, decode, exampleTypes, hasContext, hasValue }
+export { Tree, encode, decode, exampleTypes, hasContext, hasValue, mockService }
 
 export let ContextTree = _.curry(
   (


### PR DESCRIPTION
* Expose `mockService` as a top level export