### PR TITLE
Corrected the object reference used by addActions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ export let ContextTree = _.curry(
       tree,
       addActions: create =>
         F.extendOn(
-          TreeInstance,
+          this,
           create({ getNode, flat, dispatch, snapshot, extend, types, initNode })
         ),
       addReactors: create => F.extendOn(customReactors, create()),

--- a/src/index.js
+++ b/src/index.js
@@ -109,11 +109,12 @@ export let ContextTree = _.curry(
       dispatch,
       getNode,
       tree,
-      addActions: create =>
-        F.extendOn(
+      addActions(create) {
+        return F.extendOn(
           this,
           create({ getNode, flat, dispatch, snapshot, extend, types, initNode })
-        ),
+        )
+      },
       addReactors: create => F.extendOn(customReactors, create()),
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -718,4 +718,27 @@ describe('lib', () => {
       ],
     })
   })
+  it('Should not addActions on a long-gone object', () => {
+    let tree = {
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'filter',
+          type: 'facet',
+        },
+        {
+          key: 'results',
+          type: 'results',
+        },
+      ],
+    }
+    let service = sinon.spy(mockService())
+    let Tree = lib.ContextTree({ service, debounce: 1 }, tree)
+    let clonedTree = _.clone(Tree)
+    clonedTree.addActions(() => ({
+      myNewAction: _.noop
+    }))
+    expect(clonedTree.myNewAction).to.exist
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -737,7 +737,7 @@ describe('lib', () => {
     let Tree = lib.ContextTree({ service, debounce: 1 }, tree)
     let clonedTree = _.clone(Tree)
     clonedTree.addActions(() => ({
-      myNewAction: _.noop
+      myNewAction: _.noop,
     }))
     expect(clonedTree.myNewAction).to.exist
   })


### PR DESCRIPTION
TreeInstance here and the returned tree instance eventually become different pointers.

Fixes: https://github.com/smartprocure/contexture-react/pull/28/files#diff-0567311bd92839426598ee8d12d406beR24

TODOs:
- Make a unit tests that shows why this is needed.