### PR TITLE
Fix unsolicited responses exploding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.12.1
+* Catch case where unsolicited node responses from the service for nodes that have never been updated explode because of missing upatingPromise (but still log in debug mode)
+* Update mobx tests to use mobx 5
+
 # 2.12.0
 * Added `onUpdateByOthers` hook and update results example type to use it
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture-client#readme",
   "dependencies": {
-    "futil-js": "^1.43.1",
+    "futil-js": "^1.49.0",
     "lodash": "^4.17.4"
   },
   "devDependencies": {
@@ -46,7 +46,7 @@
     "duti": "^0.9.3",
     "eslint": "^4.12.1",
     "eslint-config-smartprocure": "^1.1.0",
-    "mobx": "^3.3.2",
+    "mobx": "^5.0.0",
     "mocha": "^4.0.1",
     "nyc": "^11.2.1",
     "prettier": "^1.8.2",

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,12 @@ export let ContextTree = _.curry(
           TreeInstance.onResult(decode(path), node, target)
           mergeWith((oldValue, newValue) => newValue, target, responseNode)
           extend(target, { updating: false })
-          target.updatingDeferred.resolve()
+          try {
+            target.updatingDeferred.resolve()
+          }
+          catch (e) {
+            log('Tried to resolve a node that had no updatingDeferred. This usually means there was unsolicited results from the server for a node that has never been udpated.')
+          }
         }
       }, flatten(data))
     }

--- a/src/index.js
+++ b/src/index.js
@@ -133,9 +133,10 @@ export let ContextTree = _.curry(
           extend(target, { updating: false })
           try {
             target.updatingDeferred.resolve()
-          }
-          catch (e) {
-            log('Tried to resolve a node that had no updatingDeferred. This usually means there was unsolicited results from the server for a node that has never been udpated.')
+          } catch (e) {
+            log(
+              'Tried to resolve a node that had no updatingDeferred. This usually means there was unsolicited results from the server for a node that has never been udpated.'
+            )
           }
         }
       }, flatten(data))

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -1,5 +1,5 @@
 import * as F from 'futil-js'
-import { Tree } from '../src/util/tree'
+import { Tree } from './util/tree'
 
 export let defaultMocks = ({ type }) =>
   ({


### PR DESCRIPTION
* Catch case where unsolicited node responses from the service for nodes that have never been updated explode because of missing upatingPromise (but still log in debug mode)
* Update mobx tests to use mobx 5
