### PR TITLE
MobX4 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿# 2.12.2
+* Small fix for MobX 4. Just making sure that observables are not used for comparing paths.
+
 # 2.12.1
 * Catch case where unsolicited node responses from the service for nodes that have never been updated explode because of missing upatingPromise (but still log in debug mode)
 * Update mobx tests to use mobx 5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {
@@ -46,7 +46,7 @@
     "duti": "^0.9.3",
     "eslint": "^4.12.1",
     "eslint-config-smartprocure": "^1.1.0",
-    "mobx": "^5.0.0",
+    "mobx": "^4.3.1",
     "mocha": "^4.0.1",
     "nyc": "^11.2.1",
     "prettier": "^1.8.2",

--- a/src/index.js
+++ b/src/index.js
@@ -80,9 +80,9 @@ export let ContextTree = _.curry(
         // Mark children only if it's not a parent of the target so we don't incorrectly mark siblings
         // flatMap because traversing children can create arrays
         _.flatMap(n =>
-          F.unless(isParent(snapshot(n.path), event.path), Tree.toArrayBy)(markForUpdate)(
-            n
-          )
+          F.unless(isParent(snapshot(n.path), event.path), Tree.toArrayBy)(
+            markForUpdate
+          )(n)
         )
       )(event, path)
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ export let ContextTree = _.curry(
         // Mark children only if it's not a parent of the target so we don't incorrectly mark siblings
         // flatMap because traversing children can create arrays
         _.flatMap(n =>
-          F.unless(isParent(n.path, event.path), Tree.toArrayBy)(markForUpdate)(
+          F.unless(isParent(snapshot(n.path), event.path), Tree.toArrayBy)(markForUpdate)(
             n
           )
         )

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -294,4 +294,9 @@ describe('usage with mobx should generally work', () => {
     ])
     disposer()
   })
+
+  it('should refresh properly', async () => {
+    await Tree.refresh(['root'])
+    expect(service).to.have.callCount(3)
+  })
 })


### PR DESCRIPTION
We were comparing an observable array against a normal array.
MobX 5 doesn't have this problem, since observable arrays are
indistinguishable from normal arrays in that version.

Fixes #61