### PR TITLE
Making sure we only use clean paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+﻿# 2.13.5
+* Actions should ensure the path they're receiving is clean. We'll be
+  using the snapshot function for that.
+
 # 2.13.4
 * Fix error with mobx 4 usage where event path itself is an observable.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -35,7 +35,7 @@ export default ({
     let parent = getNode(_.dropRight(1, cleanPath))
     pullOn(previous, parent.children)
     delete flat[encode(cleanPath)]
-    return dispatch({ type: 'remove', cleanPath, previous })
+    return dispatch({ type: 'remove', path: cleanPath, previous })
   },
   mutate: _.curry(async (path, value) => {
     let cleanPath = snapshot(path)

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,6 +2,13 @@ import _ from 'lodash/fp'
 import { pullOn } from 'futil-js'
 import { encode } from './util/tree'
 
+// Note:
+// When an action receives a path, it might not be a clean JavaScript array,
+// for example: in Mobx, in many cases the search tree is an Observable object
+// that includes paths that really have a type of Observable Array. These changed
+// types aren't perfect and since we don't have a way to forbid users from sending them,
+// we should at least try to clean them.
+
 export default ({
   getNode,
   flat,
@@ -12,8 +19,9 @@ export default ({
   initNode,
 }) => ({
   async add(parentPath, node) {
-    let target = getNode(parentPath)
-    let path = [...parentPath, node.key]
+    let cleanParentPath = snapshot(parentPath)
+    let target = getNode(cleanParentPath)
+    let path = [...cleanParentPath, node.key]
     // TODO: Does not currently call init on child nodes
     initNode(node, path, extend, types)
     target.children.push(node)
@@ -22,24 +30,26 @@ export default ({
     return dispatch({ type: 'add', path, node })
   },
   async remove(path) {
-    let previous = getNode(path)
-    let parent = getNode(_.dropRight(1, path))
+    let cleanPath = snapshot(path)
+    let previous = getNode(cleanPath)
+    let parent = getNode(_.dropRight(1, cleanPath))
     pullOn(previous, parent.children)
-    delete flat[encode(path)]
-    return dispatch({ type: 'remove', path, previous })
+    delete flat[encode(cleanPath)]
+    return dispatch({ type: 'remove', cleanPath, previous })
   },
   mutate: _.curry(async (path, value) => {
-    let target = getNode(path)
+    let cleanPath = snapshot(path)
+    let target = getNode(cleanPath)
     let previous = snapshot(_.omit('children', target))
     extend(target, value)
     return dispatch({
       type: 'mutate',
-      path,
+      path: cleanPath,
       previous,
       value,
       node: target,
     })
   }),
-  refresh: path => dispatch({ type: 'refresh', path }),
+  refresh: path => dispatch({ type: 'refresh', path: snapshot(path) }),
   triggerUpdate: () => dispatch({ type: 'none', path: [], autoUpdate: true }),
 })


### PR DESCRIPTION
On Mobx applications, calling our actions with observable arrays breaks our client! Here's a permanent fix.
I'm not sure what would be a better approach, so let me know or just make a better approach if you find one!

Cheers!