### PR TITLE
Mark when contextless nodes stop updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.13.5
+* Fix bug preventing nodes without contexts from being marked as no longer updating.
+
 # 2.13.4
 * Fix error with mobx 4 usage where event path itself is an observable.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -131,9 +131,11 @@ export let ContextTree = _.curry(
       F.eachIndexed((node, path) => {
         let target = flat[path]
         let responseNode = _.pick(['context', 'error'], node)
-        if (target && !_.isEmpty(responseNode) && !isStale(node, target)) {
-          TreeInstance.onResult(decode(path), node, target)
-          mergeWith((oldValue, newValue) => newValue, target, responseNode)
+        if (target && !isStale(node, target)) {
+          if (!_.isEmpty(responseNode)) {
+            TreeInstance.onResult(decode(path), node, target)
+            mergeWith((oldValue, newValue) => newValue, target, responseNode)
+          }
           extend(target, { updating: false })
           try {
             target.updatingDeferred.resolve()

--- a/test/index.js
+++ b/test/index.js
@@ -869,6 +869,35 @@ describe('lib', () => {
       expect(tree.getNode(['root', 'criteria1', 'vendors']).lastUpdateTime).to
         .not.be.null
     })
+    it('should not keep nodes without results updating forever', async () => {
+      let service = sinon.spy(mockService())
+      let Tree = ContextureClient({ debounce: 1, service })
+      let tree = Tree({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+          },
+          {
+            key: 'agencies',
+            field: 'Organization.Name',
+            type: 'facet',
+          },
+          {
+            key: 'vendors',
+            field: 'Vendor.Name',
+            type: 'text',
+          },
+        ],
+      })
+      expect(!!tree.getNode(['root', 'vendors']).updating).to.be.false
+      await tree.mutate(['root', 'agencies'], { values: ['City of Deerfield'] })
+      // Since this is `text`, it won't get a context back but should still not be updating
+      expect(!!tree.getNode(['root', 'vendors']).updating).to.be.false
+    })
   })
   it('should support subquery', async () => {
     let spy = sinon.spy(


### PR DESCRIPTION
* Fix bug preventing nodes without contexts from being marked as no longer updating.
