### PR TITLE
bump to 2.13.6 because of botched publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.13.6
+* Republish 2.13.5 which was published manually without building.
+
 # 2.13.5
 * Fix bug preventing nodes without contexts from being marked as no longer updating.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {


### PR DESCRIPTION
* Republish 2.13.5 which was published manually without building.
