### PR TITLE
Slicing children in our reactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+﻿# 2.13.7
+* Fixed an issue when mutating groups would return an observable array
+  that we wouldn't be able to parse.
+
 # 2.13.6
 * Republish 2.13.5 which was published manually without building.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.13.6",
+  "version": "2.13.7",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/reactors.js
+++ b/src/reactors.js
@@ -4,9 +4,9 @@ import { hasContext, hasValue } from './node'
 
 let reactors = {
   others: (parent, node) =>
-    parent.join === 'or' ? [] : _.difference(parent.children, [node]),
+    parent.join === 'or' ? [] : _.difference(parent.children.slice(), [node]),
   self: (parent, node) => [node],
-  all: parent => parent.children,
+  all: parent => parent.children.slice(),
   none: () => [],
   standardChange(parent, node, { previous }, reactors) {
     let needUpdate = hasContext(node)
@@ -26,7 +26,7 @@ let reactors = {
 export let StandardReactors = {
   refresh: reactors.all,
   join(parent, node, { previous }, reactor) {
-    let childrenWithValues = _.filter(hasValue, node.children)
+    let childrenWithValues = _.filter(hasValue, node.children.slice())
     let joinInverted = node.join === 'not' || previous.join === 'not'
     if (childrenWithValues.length > 1 || joinInverted) return reactor('all')
   },

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp'
 import * as F from 'futil-js'
 import { Tree } from './util/tree'
 

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -1,19 +1,32 @@
+import _ from 'lodash/fp'
 import * as F from 'futil-js'
 import { Tree } from './util/tree'
 
 export default extend => ({
-  markForUpdate(x) {
-    if (x.paused) extend(x, { missedUpdate: true })
-    else if (!x.markedForUpdate) {
-      let updatingDeferred = F.defer()
-      extend(x, {
-        markedForUpdate: true,
-        updatingPromise: updatingDeferred.promise,
-        updatingDeferred,
-      })
-    }
-    return x
-  },
+  // When a group node has the join "not" and is changed to something else,
+  // it triggers the reactor for "join", which then
+  // triggers the reactor of "all", which returns the children,
+  // which makes it so the array of children is sent to markForUpdate,
+  // which crashes since we can't call MobX's set() on an array.
+  //
+  // Our current solution is to ensure that we are working over an array
+  // (by checking if the input object is an array and wrapping it in an array if it's not),
+  // then we iterate the array with the markForUpdate traversal.
+  markForUpdate: _.flow(
+    x => (x.length ? x : [x]), // _.castArray doesn't work with MobX arrays
+    _.map(x => {
+      if (x.paused) extend(x, { missedUpdate: true })
+      else if (!x.markedForUpdate) {
+        let updatingDeferred = F.defer()
+        extend(x, {
+          markedForUpdate: true,
+          updatingPromise: updatingDeferred.promise,
+          updatingDeferred,
+        })
+      }
+      return x
+    })
+  ),
   markLastUpdate: time =>
     Tree.walk(child => {
       if (child.markedForUpdate) extend(child, { lastUpdateTime: time })

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -3,30 +3,18 @@ import * as F from 'futil-js'
 import { Tree } from './util/tree'
 
 export default extend => ({
-  // When a group node has the join "not" and is changed to something else,
-  // it triggers the reactor for "join", which then
-  // triggers the reactor of "all", which returns the children,
-  // which makes it so the array of children is sent to markForUpdate,
-  // which crashes since we can't call MobX's set() on an array.
-  //
-  // Our current solution is to ensure that we are working over an array
-  // (by checking if the input object is an array and wrapping it in an array if it's not),
-  // then we iterate the array with the markForUpdate traversal.
-  markForUpdate: _.flow(
-    x => (x.length ? x : [x]), // _.castArray doesn't work with MobX arrays
-    _.map(x => {
-      if (x.paused) extend(x, { missedUpdate: true })
-      else if (!x.markedForUpdate) {
-        let updatingDeferred = F.defer()
-        extend(x, {
-          markedForUpdate: true,
-          updatingPromise: updatingDeferred.promise,
-          updatingDeferred,
-        })
-      }
-      return x
-    })
-  ),
+  markForUpdate(x) {
+    if (x.paused) extend(x, { missedUpdate: true })
+    else if (!x.markedForUpdate) {
+      let updatingDeferred = F.defer()
+      extend(x, {
+        markedForUpdate: true,
+        updatingPromise: updatingDeferred.promise,
+        updatingDeferred,
+      })
+    }
+    return x
+  },
   markLastUpdate: time =>
     Tree.walk(child => {
       if (child.markedForUpdate) extend(child, { lastUpdateTime: time })

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -332,4 +332,43 @@ describe('usage with mobx should generally work', () => {
     expect(tree.getNode(resultsNode.path).page).to.equal(1)
     expect(service).to.have.callCount(2)
   })
+  it('the markForUpdate traversal should not try to alter arrays', async () => {
+    // When a group node has the join "not" and is changed to something else,
+    // it triggers the reactor for "join", which then
+    // triggers the reactor of "all", which returns the children,
+    // which makes it so the array of children is sent to markForUpdate,
+    // which crashes since we can't call MobX's set() on an array.
+    //
+    // Our current solution is to ensure that we are working over an array
+    // (by checking if the input object is an array and wrapping it in an array if it's not),
+    // then we iterate the array with the markForUpdate traversal.
+    service.reset()
+    let Tree = ContextureMobx({ debounce: 1, service })
+    let tree = Tree({
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'results',
+          type: 'results',
+          page: 1,
+        },
+        {
+          key: 'subgroup',
+          type: 'group',
+          join: 'not',
+          children: [
+            {
+              key: 'facetic',
+              type: 'facet',
+              field: 'facetfield',
+              value: 'some value',
+            },
+          ],
+        },
+      ],
+    })
+    await tree.refresh(['root'])
+    await tree.mutate(['root', 'subgroup'], { join: 'and' })
+  })
 })

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -333,7 +333,7 @@ describe('usage with mobx should generally work', () => {
     expect(service).to.have.callCount(2)
   })
   it(`should be possible to change a group's join property`, async () => {
-		// This wasn't possible before this PR: https://github.com/smartprocure/contexture-client/pull/74
+    // This wasn't possible before this PR: https://github.com/smartprocure/contexture-client/pull/74
     service.reset()
     let Tree = ContextureMobx({ debounce: 1, service })
     let tree = Tree({

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -332,16 +332,8 @@ describe('usage with mobx should generally work', () => {
     expect(tree.getNode(resultsNode.path).page).to.equal(1)
     expect(service).to.have.callCount(2)
   })
-  it('the markForUpdate traversal should not try to alter arrays', async () => {
-    // When a group node has the join "not" and is changed to something else,
-    // it triggers the reactor for "join", which then
-    // triggers the reactor of "all", which returns the children,
-    // which makes it so the array of children is sent to markForUpdate,
-    // which crashes since we can't call MobX's set() on an array.
-    //
-    // Our current solution is to ensure that we are working over an array
-    // (by checking if the input object is an array and wrapping it in an array if it's not),
-    // then we iterate the array with the markForUpdate traversal.
+  it(`should be possible to change a group's join property`, async () => {
+		// This wasn't possible before this PR: https://github.com/smartprocure/contexture-client/pull/74
     service.reset()
     let Tree = ContextureMobx({ debounce: 1, service })
     let tree = Tree({


### PR DESCRIPTION
Children can be Observable Arrays, which are different from normal arrays (as far as MobX 4 can tell). This becomes an issue on MobX, specially when changing a group from having a `not` join property to any other value. For that reason, we're slicing them.

![](https://78.media.tumblr.com/34c496599e3818c788cc4a45b578c420/tumblr_oqbpy858lc1vxy2a1o1_500.gif)