### PR TITLE
validate for geo example type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.18.0
+* Added validate function to `geo` example type
+
 # 2.17.3
 * Added defaults and reactors for `text`'s `operator`.
 * Added `tagsText`, which is just like text but supports an array of values.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.17.3",
+  "version": "2.18.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -175,6 +175,8 @@ export default stampKey('type', {
     },
   },
   geo: {
+    validate: x =>
+      !!((x.location || (x.latitude && x.longitude)) && x.radius && x.operator),
     reactors: {
       location: 'others',
       latitude: 'others',


### PR DESCRIPTION
Add geo validate function just like we have it on the server side implementation for ES

https://github.com/smartprocure/contexture-elasticsearch/blob/master/src/example-types/geo.js#L48-L53