### PR TITLE
Fixed deep bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+﻿# 2.18.1
+* Fixed deep bug: afterSearch should be called at the moment we
+  receive new values. This would cause nodes previously marked for
+  update to not call afterSearch because these nodes weren't marked by
+  the current dispatch.
+
 # 2.18.0
 * Added validate function to `geo` example type
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {


### PR DESCRIPTION
Fixed deep bug: afterSearch should be called at the moment we
receive new values. This would cause nodes previously marked for
update to not call afterSearch because these nodes weren't marked by
the current dispatch.