### PR TITLE
Add missing defaults for `subquery` and `savedSearch` example types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.19.0
+﻿# 2.19.1
+* Add missing defaults for `subquery` and `savedSearch` example types.
+
+# 2.19.0
 * Add `subquery` and `savedSearch` example types.
 
 # 2.18.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -377,12 +377,22 @@ export default stampKey('type', {
       search: 'others',
       searchId: 'others',
     },
+    defaults: {
+      searchId: null,
+      search: null,
+      localField: null,
+      foreignField: null, 
+    }
   },
   savedSearch: {
     validate: node => node.search || node.searchId,
     reactors: {
       search: 'others',
       searchId: 'others',
+    },
+    defaults: {
+      searchId: null,
+      search: null,
     },
   },
 })

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -381,8 +381,8 @@ export default stampKey('type', {
       searchId: null,
       search: null,
       localField: null,
-      foreignField: null, 
-    }
+      foreignField: null,
+    },
   },
   savedSearch: {
     validate: node => node.search || node.searchId,


### PR DESCRIPTION
Add missing defaults for `subquery` and `savedSearch` example types.