### PR TITLE
Add value reactor for mongoId example type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.19.1
+﻿# 2.19.2
+* Add `value` reactor for `mongoId` example type
+
+# 2.19.1
 * Add missing defaults for `subquery` and `savedSearch` example types.
 
 # 2.19.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -100,6 +100,7 @@ export default stampKey('type', {
   mongoId: {
     validate: validateValues,
     reactors: {
+      value: 'others',
       values: 'others',
     },
     subquery: {


### PR DESCRIPTION
The `mongoId` mongo example type allows for its value to be set in either the `values` or the `value` fields, however, we only ran reactors on mutations to the `values` field. This PR fixes it so we also run reactors on mutations to `value`.