### PR TITLE
Add clear action to reset a node's value to its defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.19.2
+﻿# 2.20.0
+* Add `clear` action to reset a node's value to its defaults
+
+# 2.19.2
 * Add `value` reactor for `mongoId` example type
 
 # 2.19.1

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The following methods are exposed on an instantiated client
 | add | `async (path, newNode) -> await searchCompleted` | Adds a node to the tree as a child of the specified path. You can await this for when updates settle and relevant searches are completed. |
 | remove | `async path -> await searchCompleted` | Removes a node at the specified path. You can await this for when updates settle and relevant searches are completed. |
 | mutate | `async (path, deltas) -> await searchCompleted` | Mutates the node at the given path with the new values. You can await this for when updates settle and relevant searches are completed. |
+| clear | `async path -> await searchCompleted` | Resets the node's values to those given on the node type's `defaults` (except `field`)
 | triggerUpdate | `async () -> await searchCompleted` | Will trigger an update with a `none` reactor, updating only nodes that are already marked for update. This is useful when `disableAutoUpdate` is set to true. |
 | dispatch | `async event -> await searchCompleted` | A lower level, core method of interaction (called automatically by the actions above). You can await this for when updates settle and relevant searches are completed. |
 | getNode | `[path] -> node` | Lookup a node by a path (array of keys). |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.19.2",
+  "version": "2.20.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { pullOn } from 'futil-js'
 import { encode } from './util/tree'
+import { getTypeProp } from './types'
 
 export default ({
   getNode,
@@ -10,36 +11,46 @@ export default ({
   types,
   extend,
   initNode,
-}) => ({
-  async add(parentPath, node) {
-    let target = getNode(parentPath)
-    let path = [...parentPath, node.key]
-    // TODO: Does not currently call init on child nodes
-    initNode(node, path, extend, types)
-    target.children.push(node)
-    // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
-    flat[encode(path)] = target.children[target.children.length - 1]
-    return dispatch({ type: 'add', path, node })
-  },
-  async remove(path) {
-    let previous = getNode(path)
-    let parent = getNode(_.dropRight(1, path))
-    pullOn(previous, parent.children)
-    delete flat[encode(path)]
-    return dispatch({ type: 'remove', path, previous })
-  },
-  mutate: _.curry(async (path, value) => {
-    let target = getNode(path)
-    let previous = snapshot(_.omit('children', target))
-    extend(target, value)
-    return dispatch({
-      type: 'mutate',
+}) => {
+  let actions = {
+    async add(parentPath, node) {
+      let target = getNode(parentPath)
+      let path = [...parentPath, node.key]
+      // TODO: Does not currently call init on child nodes
+      initNode(node, path, extend, types)
+      target.children.push(node)
+      // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
+      flat[encode(path)] = target.children[target.children.length - 1]
+      return dispatch({ type: 'add', path, node })
+    },
+    async remove(path) {
+      let previous = getNode(path)
+      let parent = getNode(_.dropRight(1, path))
+      pullOn(previous, parent.children)
+      delete flat[encode(path)]
+      return dispatch({ type: 'remove', path, previous })
+    },
+    mutate: _.curry(async (path, value) => {
+      let target = getNode(path)
+      let previous = snapshot(_.omit('children', target))
+      extend(target, value)
+      return dispatch({
+        type: 'mutate',
+        path,
+        previous,
+        value,
+        node: target,
+      })
+    }),
+    refresh: path => dispatch({ type: 'refresh', path }),
+    triggerUpdate: () => dispatch({ type: 'none', path: [], autoUpdate: true }),
+  }
+
+  actions.clear = path =>
+    actions.mutate(
       path,
-      previous,
-      value,
-      node: target,
-    })
-  }),
-  refresh: path => dispatch({ type: 'refresh', path }),
-  triggerUpdate: () => dispatch({ type: 'none', path: [], autoUpdate: true }),
-})
+      _.omit(['field'], getTypeProp(types, 'defaults', getNode(path)))
+    )
+
+  return actions
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -12,45 +12,55 @@ export default ({
   extend,
   initNode,
 }) => {
-  let actions = {
-    async add(parentPath, node) {
-      let target = getNode(parentPath)
-      let path = [...parentPath, node.key]
-      // TODO: Does not currently call init on child nodes
-      initNode(node, path, extend, types)
-      target.children.push(node)
-      // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
-      flat[encode(path)] = target.children[target.children.length - 1]
-      return dispatch({ type: 'add', path, node })
-    },
-    async remove(path) {
-      let previous = getNode(path)
-      let parent = getNode(_.dropRight(1, path))
-      pullOn(previous, parent.children)
-      delete flat[encode(path)]
-      return dispatch({ type: 'remove', path, previous })
-    },
-    mutate: _.curry(async (path, value) => {
-      let target = getNode(path)
-      let previous = snapshot(_.omit('children', target))
-      extend(target, value)
-      return dispatch({
-        type: 'mutate',
-        path,
-        previous,
-        value,
-        node: target,
-      })
-    }),
-    refresh: path => dispatch({ type: 'refresh', path }),
-    triggerUpdate: () => dispatch({ type: 'none', path: [], autoUpdate: true }),
+  let add = async (parentPath, node) => {
+    let target = getNode(parentPath)
+    let path = [...parentPath, node.key]
+    // TODO: Does not currently call init on child nodes
+    initNode(node, path, extend, types)
+    target.children.push(node)
+    // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
+    flat[encode(path)] = target.children[target.children.length - 1]
+    return dispatch({ type: 'add', path, node })
   }
 
-  actions.clear = path =>
-    actions.mutate(
+  let remove = async path => {
+    let previous = getNode(path)
+    let parent = getNode(_.dropRight(1, path))
+    pullOn(previous, parent.children)
+    delete flat[encode(path)]
+    return dispatch({ type: 'remove', path, previous })
+  }
+
+  let mutate = _.curry(async (path, value) => {
+    let target = getNode(path)
+    let previous = snapshot(_.omit('children', target))
+    extend(target, value)
+    return dispatch({
+      type: 'mutate',
+      path,
+      previous,
+      value,
+      node: target,
+    })
+  })
+
+  let refresh = path => dispatch({ type: 'refresh', path })
+
+  let triggerUpdate = () =>
+    dispatch({ type: 'none', path: [], autoUpdate: true })
+
+  let clear = path =>
+    mutate(
       path,
       _.omit(['field'], getTypeProp(types, 'defaults', getNode(path)))
     )
 
-  return actions
+  return {
+    add,
+    remove,
+    mutate,
+    refresh,
+    triggerUpdate,
+    clear,
+  }
 }


### PR DESCRIPTION
The action is just a mutate with default values from the node type definition (save for the `field` property). It seemed easier to do it this way instead of adding a new property in the node's type definition to include/exclude properties to reset to their default values.