### PR TITLE
Serialize a node's paused field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.20.0
+﻿# 2.21.0
+* Serialize a node's `paused` field
+
+# 2.20.0
 * Add `clear` action to reset a node's value to its defaults
 
 # 2.19.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/node.js
+++ b/src/node.js
@@ -16,7 +16,7 @@ export let defaults = {
   updatingDeferred: null,
 }
 export let internalStateKeys = {
-  ..._.omit(['type'], defaults),
+  ..._.omit(['type', 'paused'], defaults),
   validate: null,
   onMarkForUpdate: null,
   afterSearch: null,


### PR DESCRIPTION
The line between what to serialize and not serialize is blurry and it
depends on the requirements of a specific application. It turns out we
require to maintain this state in a client of the library.

A more useful approach would be to parametrize the fields to serialize,
but this will do for now.