### PR TITLE
Fix bug with replace not inserting at the right index with mobx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.22.0
+﻿# 2.22.1
+* Fix bug with replace not inserting at the right index with mobx
+
+# 2.22.0
 * Add nested pause actions (pauseNested, unpauseNested, isPausedNested)
 * Add move action
 * Add wrapInGroup action

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -80,9 +80,8 @@ export default config => {
 
   let replace = (path, node) => {
     let parentPath = _.dropRight(1, path)
-    // Snapshot is for mobx 4 support since observable nodes apparently throw errors
     let index = _.findIndex(
-      snapshot(getNode(path)),
+      x => x === getNode(path),
       getNode(parentPath).children
     )
     remove(path)

--- a/test/index.js
+++ b/test/index.js
@@ -1243,6 +1243,8 @@ let AllTests = ContextureClient => {
     })
     expect(tree.getNode(['root', 'criteria'])).to.not.exist
     expect(tree.getNode(['root', 'criteria1']).values).to.deep.equal([])
+    // Confirm it's at the right index
+    expect(tree.tree.children[1].key).to.deep.equal('criteria1')
   })
   it('should wrapInGroup replace', async () => {
     let service = sinon.spy(mockService())


### PR DESCRIPTION
Fix bug with replace not inserting at the right index with mobx