### PR TITLE
Add _.toArray to actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 2.22.2
+﻿# 2.22.3
+* Add `_.toArray` to actions to handle ObservableArray paths
+
+# 2.22.2
 * Set defaults for geo location and radius
 
 # 2.22.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -10,6 +10,8 @@ let pushOrSpliceOn = (array, item, index) => {
   return array
 }
 
+let arrayDropLast = _.flow(_.toArray, _.dropRight(1))
+
 export default config => {
   let {
     getNode,
@@ -42,7 +44,7 @@ export default config => {
 
   let remove = async path => {
     let previous = getNode(path)
-    let parentPath = _.dropRight(1, path)
+    let parentPath = arrayDropLast(path)
     let parent = getNode(parentPath)
     pullOn(previous, parent.children)
 
@@ -79,7 +81,7 @@ export default config => {
     )
 
   let replace = (path, node) => {
-    let parentPath = _.dropRight(1, path)
+    let parentPath = arrayDropLast(path)
     let index = _.findIndex(
       x => x === getNode(path),
       getNode(parentPath).children
@@ -91,7 +93,7 @@ export default config => {
   let { wrapInGroup } = wrap(config, { mutate, replace, add })
 
   let move = (path, { path: targetPath, index: targetIndex } = {}) => {
-    let parentPath = _.dropRight(1, path)
+    let parentPath = arrayDropLast(path)
     targetPath = targetPath || parentPath
 
     let node = getNode(path)
@@ -110,7 +112,7 @@ export default config => {
   let mutateNested = (path, payload) =>
     _.flow(
       getNode,
-      Tree.toArrayBy(node => mutate(node.path.slice(), payload)),
+      Tree.toArrayBy(node => mutate(_.toArray(node.path), payload)),
       x => Promise.all(x)
     )(path)
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -10,7 +10,10 @@ let pushOrSpliceOn = (array, item, index) => {
   return array
 }
 
-let arrayDropLast = _.flow(_.toArray, _.dropRight(1))
+let arrayDropLast = _.flow(
+  _.toArray,
+  _.dropRight(1)
+)
 
 export default config => {
   let {

--- a/src/reactors.js
+++ b/src/reactors.js
@@ -4,7 +4,9 @@ import { hasContext, hasValue } from './node'
 
 let reactors = {
   others: (parent, node) =>
-    parent.join === 'or' ? [] : _.difference(_.toArray(parent.children), [node]),
+    parent.join === 'or'
+      ? []
+      : _.difference(_.toArray(parent.children), [node]),
   self: (parent, node) => [node],
   all: parent => _.toArray(parent.children),
   none: () => [],
@@ -26,7 +28,10 @@ let reactors = {
 export let StandardReactors = {
   refresh: reactors.all,
   join(parent, node, { previous }, reactor) {
-    let childrenWithValues = _.flow(_.toArray, _.filter(hasValue))(node.children)
+    let childrenWithValues = _.flow(
+      _.toArray,
+      _.filter(hasValue)
+    )(node.children)
     let joinInverted = node.join === 'not' || previous.join === 'not'
     if (childrenWithValues.length > 1 || joinInverted) return reactor('all')
   },

--- a/src/reactors.js
+++ b/src/reactors.js
@@ -4,9 +4,9 @@ import { hasContext, hasValue } from './node'
 
 let reactors = {
   others: (parent, node) =>
-    parent.join === 'or' ? [] : _.difference(parent.children.slice(), [node]),
+    parent.join === 'or' ? [] : _.difference(_.toArray(parent.children), [node]),
   self: (parent, node) => [node],
-  all: parent => parent.children.slice(),
+  all: parent => _.toArray(parent.children),
   none: () => [],
   standardChange(parent, node, { previous }, reactors) {
     let needUpdate = hasContext(node)
@@ -26,7 +26,7 @@ let reactors = {
 export let StandardReactors = {
   refresh: reactors.all,
   join(parent, node, { previous }, reactor) {
-    let childrenWithValues = _.filter(hasValue, node.children.slice())
+    let childrenWithValues = _.flow(_.toArray, _.filter(hasValue))(node.children)
     let joinInverted = node.join === 'not' || previous.join === 'not'
     if (childrenWithValues.length > 1 || joinInverted) return reactor('all')
   },

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -264,7 +264,10 @@ describe('usage with mobx should generally work', () => {
     })
     expect(service).to.have.callCount(1)
     expect(
-      Tree.getNode(['root', 'results']).context.results.slice()
+      _.flow(
+        _.get(['context', 'results']),
+        _.toArray
+      )(Tree.getNode(['root', 'results']))
     ).to.deep.equal([
       {
         title: 'Some result',
@@ -283,7 +286,10 @@ describe('usage with mobx should generally work', () => {
     })
     expect(service).to.have.callCount(2)
     expect(
-      Tree.getNode(['root', 'results']).context.results.slice()
+      _.flow(
+        _.get(['context', 'results']),
+        _.toArray
+      )(Tree.getNode(['root', 'results']))
     ).to.deep.equal([
       {
         title: 'New values',


### PR DESCRIPTION
The first step in factoring out contexture-react's [ContextureClientBridge](https://github.com/smartprocure/contexture-react/blob/master/src/queryBuilder/QueryBuilder.js). To avoid any funny business, we convert node paths that are MobX ObservableArrays (as is the case in contexture-react) to regular arrays before using them in tree operations. Right now, that's done inside ContextureClientBridge in contexture-react; this PR moves it into contexture-client instead.

We're currently using `Array.slice()` for this exact purpose elsewhere within contexture-client (smartprocure/contexture-client#74). It seems that `_.toArray` is better anyway (smartprocure/contexture-react#120), so for consistency, I also changed the existing occurrences of `slice` to `_.toArray`.