### PR TITLE
Add transform function support to `replace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.24.0
+* Update `replace` action to support taking a transform function as an argument
+
 # 2.23.0
 * Add `onError` event to be triggered on service exception
 

--- a/README.md
+++ b/README.md
@@ -125,15 +125,10 @@ When picking field reactors, you should use the `others` reactor for things that
 | onUpdateByOthers | `(node, extend) => {}` | Called when a node is markedForUpdate by an event dispatched to a different node, which should generically capture all events where something caused the relevant filters to change and exclude anything that only affects itself. This is typically used to do things like reset paging since that should be reset when relevant filters change. |
 
 ### Run Time
-The following methods are exposed on an instantiated client
+The following methods are exposed on an instantiated client:
 
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
-| add | `async (path, newNode, {index}) -> await searchCompleted` | Adds a node to the tree as a child of the specified path. You can await this for when updates settle and relevant searches are completed. You can optionally pass an options object as the third param to specify the index where to add the node. The node can be a group with children. |
-| remove | `async path -> await searchCompleted` | Removes a node at the specified path. You can await this for when updates settle and relevant searches are completed. Will also remove children of the target node. |
-| mutate | `async (path, deltas) -> await searchCompleted` | Mutates the node at the given path with the new values. You can await this for when updates settle and relevant searches are completed. |
-| clear | `async path -> await searchCompleted` | Resets the node's values to those given on the node type's `defaults` (except `field`)
-| triggerUpdate | `async () -> await searchCompleted` | Will trigger an update with a `none` reactor, updating only nodes that are already marked for update. This is useful when `disableAutoUpdate` is set to true. |
 | dispatch | `async event -> await searchCompleted` | A lower level, core method of interaction (called automatically by the actions above). You can await this for when updates settle and relevant searches are completed. |
 | getNode | `[path] -> node` | Lookup a node by a path (array of keys). |
 | serialize | `() => tree` | Returns a snapshot of the tree without any of the temporary state like updating flags. |
@@ -142,12 +137,26 @@ The following methods are exposed on an instantiated client
 | addActions | `(({ getNode, flat, dispatch, snapshot, extend, types, initNode }) => {actionsMethods} ) => null` | *Experimental* A method for extending the client with new actions on a per instance basis. You pass in a function which takes an object containing internal helpers and returns an object with actions that get extended onto the tree instance. |
 | addReactors | `(() => {customReactors}) => null` | *Experimental* A method for adding new reactors on a per instance basis. You pass in a function which returns an object of new reactors to support (`{reactorName: reactorFunction}`). Reactors are passed `(parent, node, event, reactor, types, lookup)` and are expected to return an array of affected nodes. |
 | subquery | `(targetPath, sourceTree, sourcePath, mapSubqueryValues?) => {}` | Sets up a subquery, using the types passed in to the client and assuming this tree instance is the target tree. For more info, see the [subquery](#Subquery) section below. |
-| replace | `async (path, node) -> await searchCompleted` | Replaces a the node at the given path with the new node. You can await this for when updates settle and relevant searches are completed. |
-| wrapInGroup | `async (path, newNode) -> await searchCompleted` | Wraps the node at the provided path in a group described by `newNode`. The node will be replaced it on its parent's children unless it is root node (with a nul parent). If the node has no parent, it will be done in place by mutating the node into the group described by `newNode` with the original node as it's only child. You can await this for when updates settle and relevant searches are completed. |
-| move | `async (path, { path, index }) -> await searchCompleted` | Moves the node at the provided path (first argument) to the target location provided in the second parameter. If the target path is not specified, it will default to the current node's group. If the target index isn't provided, it will default to moving to the end of the target group. You can await this for when updates settle and relevant searches are completed. Useful for drag and drop query builder interfaces that let you move nodes around in and between groups. |
-| pauseNested | `async (path) -> await searchCompleted` | Recursively set paused to true for the node at the path and all its children. You can await this for when updates settle and relevant searches are completed. |
-| unpauseNested | `async (path) -> await searchCompleted` | Recursively set paused to false for the node at the path and all its children. You can await this for when updates settle and relevant searches are completed. |
-| isPausedNested | `async (path) -> bool` | Returns a bool for whether the node at the path and all of its children are paused. |
+
+#### Actions
+
+Client methods that mutate or otherwise act on nodes are known as **actions**. Except for `isPausedNested`, you can await these for when updates settle and relevant searches are completed. Conventionally, actions take a node path as their first parameter. 
+
+Note that it's also possible to add custom actions to a client instance through the `addActions` method (see the table above for more details).
+
+| Name | Signature | Description |
+| ---- | --------- | ----------- |
+| add | `async (path, newNode, {index}) -> await searchCompleted` | Adds a node to the tree as a child of the specified path. You can optionally pass an options object as the third param to specify the index where to add the node. The node can be a group with children. |
+| remove | `async path -> await searchCompleted` | Removes a node at the specified path. Will also remove children of the target node. |
+| mutate | `async (path, deltas) -> await searchCompleted` | Mutates the node at the given path with the new values. |
+| triggerUpdate | `async () -> await searchCompleted` | Will trigger an update with a `none` reactor, updating only nodes that are already marked for update. This is useful when `disableAutoUpdate` is set to true. |
+| clear | `async path -> await searchCompleted` | Resets the node's values to those given on the node type's `defaults` (except `field`) |
+| replace | `async (path, newNode | transform) -> await searchCompleted` | Replaces the node at the given path with a new node. Accepts either a new node, or a `node -> newNode` transform function. If a function is given, it is called on the node at `path`, and the result is then used in `replace`. |
+| wrapInGroup | `async (path, newNode) -> await searchCompleted` | Wraps the node at the provided path in a group described by `newNode`. The node will be replaced it on its parent's children unless it is root node (with a nul parent). If the node has no parent, it will be done in place by mutating the node into the group described by `newNode` with the original node as it's only child. |
+| move | `async (path, { path, index }) -> await searchCompleted` | Moves the node at the provided path (first argument) to the target location provided in the second parameter. If the target path is not specified, it will default to the current node's group. If the target index isn't provided, it will default to moving to the end of the target group. Useful for drag and drop query builder interfaces that let you move nodes around in and between groups. |
+| pauseNested | `async (path) -> await searchCompleted` | Recursively set paused to true for the node at the path and all its children. |
+| unpauseNested | `async (path) -> await searchCompleted` | Recursively set paused to false for the node at the path and all its children. |
+| isPausedNested | `async (path) -> bool` | Returns a bool (*not* a promise) for whether the node at the path and all of its children are paused. |
 
 #### Node Run Time
 The following methods can be added to individual nodes (just set them on the object returned by getNode)

--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ The following methods are exposed on an instantiated client:
 | addActions | `(({ getNode, flat, dispatch, snapshot, extend, types, initNode }) => {actionsMethods} ) => null` | *Experimental* A method for extending the client with new actions on a per instance basis. You pass in a function which takes an object containing internal helpers and returns an object with actions that get extended onto the tree instance. |
 | addReactors | `(() => {customReactors}) => null` | *Experimental* A method for adding new reactors on a per instance basis. You pass in a function which returns an object of new reactors to support (`{reactorName: reactorFunction}`). Reactors are passed `(parent, node, event, reactor, types, lookup)` and are expected to return an array of affected nodes. |
 | subquery | `(targetPath, sourceTree, sourcePath, mapSubqueryValues?) => {}` | Sets up a subquery, using the types passed in to the client and assuming this tree instance is the target tree. For more info, see the [subquery](#Subquery) section below. |
+| isPausedNested | `path -> bool` | Returns a bool for whether the node at the path and all of its children are paused. |
 
 #### Actions
 
-Client methods that mutate or otherwise act on nodes are known as **actions**. Except for `isPausedNested`, you can await these for when updates settle and relevant searches are completed. Conventionally, actions take a node path as their first parameter. 
+Client methods that mutate or otherwise act on nodes are known as **actions**. You can await these for when updates settle and relevant searches are completed. Conventionally, actions take a node path as their first parameter. 
 
 Note that it's also possible to add custom actions to a client instance through the `addActions` method (see the table above for more details).
 
@@ -151,12 +152,11 @@ Note that it's also possible to add custom actions to a client instance through 
 | mutate | `async (path, deltas) -> await searchCompleted` | Mutates the node at the given path with the new values. |
 | triggerUpdate | `async () -> await searchCompleted` | Will trigger an update with a `none` reactor, updating only nodes that are already marked for update. This is useful when `disableAutoUpdate` is set to true. |
 | clear | `async path -> await searchCompleted` | Resets the node's values to those given on the node type's `defaults` (except `field`) |
-| replace | `async (path, newNode | transform) -> await searchCompleted` | Replaces the node at the given path with a new node. Accepts either a new node, or a `node -> newNode` transform function. If a function is given, it is called on the node at `path`, and the result is then used in `replace`. |
+| replace | `async (path, newNodeOrTransform) -> await searchCompleted` | Replaces the node at the given path with a new node. Accepts either a node object or a `node -> newNode` transform function as its second argument. If a function is given, it is called on the node at `path`, and the result is then used in `replace`. |
 | wrapInGroup | `async (path, newNode) -> await searchCompleted` | Wraps the node at the provided path in a group described by `newNode`. The node will be replaced it on its parent's children unless it is root node (with a nul parent). If the node has no parent, it will be done in place by mutating the node into the group described by `newNode` with the original node as it's only child. |
 | move | `async (path, { path, index }) -> await searchCompleted` | Moves the node at the provided path (first argument) to the target location provided in the second parameter. If the target path is not specified, it will default to the current node's group. If the target index isn't provided, it will default to moving to the end of the target group. Useful for drag and drop query builder interfaces that let you move nodes around in and between groups. |
-| pauseNested | `async (path) -> await searchCompleted` | Recursively set paused to true for the node at the path and all its children. |
-| unpauseNested | `async (path) -> await searchCompleted` | Recursively set paused to false for the node at the path and all its children. |
-| isPausedNested | `async (path) -> bool` | Returns a bool (*not* a promise) for whether the node at the path and all of its children are paused. |
+| pauseNested | `async path -> await searchCompleted` | Recursively set paused to true for the node at the path and all its children. |
+| unpauseNested | `async path -> await searchCompleted` | Recursively set paused to false for the node at the path and all its children. |
 
 #### Node Run Time
 The following methods can be added to individual nodes (just set them on the object returned by getNode)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -86,10 +86,7 @@ export default config => {
   let replace = (path, transform) => {
     let parentPath = arrayDropLast(path)
     let node = getNode(path)
-    let index = _.findIndex(
-      x => x === node,
-      getNode(parentPath).children
-    )
+    let index = _.findIndex(x => x === node, getNode(parentPath).children)
     let newNode = F.callOrReturn(transform, node)
     remove(path)
     return add(parentPath, newNode, { index })

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { pullOn } from 'futil-js'
+import F from 'futil-js'
 import { encode, Tree } from '../util/tree'
 import { getTypeProp } from '../types'
 import wrap from './wrap'
@@ -49,7 +49,7 @@ export default config => {
     let previous = getNode(path)
     let parentPath = arrayDropLast(path)
     let parent = getNode(parentPath)
-    pullOn(previous, parent.children)
+    F.pullOn(previous, parent.children)
 
     Tree.walk((node, index, [parent = {}]) => {
       let path = [...(parent.path || parentPath), node.key]
@@ -83,14 +83,16 @@ export default config => {
       _.omit(['field'], getTypeProp(types, 'defaults', getNode(path)))
     )
 
-  let replace = (path, node) => {
+  let replace = (path, transform) => {
     let parentPath = arrayDropLast(path)
+    let node = getNode(path)
     let index = _.findIndex(
-      x => x === getNode(path),
+      x => x === node,
       getNode(parentPath).children
     )
+    let newNode = F.callOrReturn(transform, node)
     remove(path)
-    return add(parentPath, node, { index })
+    return add(parentPath, newNode, { index })
   }
 
   let { wrapInGroup } = wrap(config, { mutate, replace, add })
@@ -102,7 +104,7 @@ export default config => {
     let node = getNode(path)
     if (_.isEqual(parentPath, targetPath)) {
       // Same group, no dispatch or updating of paths needed - just rearrange children
-      pullOn(node, getNode(parentPath).children)
+      F.pullOn(node, getNode(parentPath).children)
       pushOrSpliceOn(getNode(targetPath).children, node, targetIndex)
     } else {
       return Promise.all([

--- a/test/index.js
+++ b/test/index.js
@@ -1298,14 +1298,26 @@ let AllTests = ContextureClient => {
         },
       ],
     })
-    await tree.replace(['root', 'criteria'], {
-      key: 'criteria1',
-      type: 'facet',
-    })
+    expect(tree.tree.children[1].key).to.deep.equal('criteria')
+    // Replace with a transform
+    await tree.replace(
+      ['root', 'criteria'], 
+      node => ({...node, key: 'criteria1', values: [1, 2, 3]})
+    )
     expect(tree.getNode(['root', 'criteria'])).to.not.exist
-    expect(tree.getNode(['root', 'criteria1']).values).to.deep.equal([])
+    expect(tree.getNode(['root', 'criteria1']).values).to.deep.equal([1, 2, 3])
+    expect(tree.getNode(['root', 'criteria1']).children).to.have.lengthOf(2)
     // Confirm it's at the right index
     expect(tree.tree.children[1].key).to.deep.equal('criteria1')
+    // Replace with a new object
+    await tree.replace(['root', 'criteria1'], () => ({
+      key: 'criteria2',
+      type: 'facet',
+    }))
+    expect(tree.getNode(['root', 'criteria'])).to.not.exist
+    expect(tree.getNode(['root', 'criteria2']).values).to.deep.equal([])
+    expect(tree.getNode(['root', 'criteria2']).children).to.not.exist
+    expect(tree.tree.children[1].key).to.deep.equal('criteria2')
   })
   it('should wrapInGroup replace', async () => {
     let service = sinon.spy(mockService())

--- a/test/index.js
+++ b/test/index.js
@@ -1300,10 +1300,11 @@ let AllTests = ContextureClient => {
     })
     expect(tree.tree.children[1].key).to.deep.equal('criteria')
     // Replace with a transform
-    await tree.replace(
-      ['root', 'criteria'], 
-      node => ({...node, key: 'criteria1', values: [1, 2, 3]})
-    )
+    await tree.replace(['root', 'criteria'], node => ({
+      ...node,
+      key: 'criteria1',
+      values: [1, 2, 3],
+    }))
     expect(tree.getNode(['root', 'criteria'])).to.not.exist
     expect(tree.getNode(['root', 'criteria1']).values).to.deep.equal([1, 2, 3])
     expect(tree.getNode(['root', 'criteria1']).children).to.have.lengthOf(2)


### PR DESCRIPTION
Closes #106

The test diff looks worse than it actually is; the old `replace` assertions are still there, just changed to `criteria2` so I could add the new ones above them as `criteria1`.