### PR TITLE
Adding processResponse so we can continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.23.1
+* Add `resetUpdate` to normalize the tree post service exception
+
 # 2.23.0
 * Add `onError` event to be triggered on service exception
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.23.1
-* Add `resetUpdate` to normalize the tree post service exception
+* Await `processResponse` to normalize the tree post service exception
 
 # 2.23.0
 * Add `onError` event to be triggered on service exception

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -130,8 +130,8 @@ export let ContextTree = _.curry(
       try {
         await processResponse(await service(dto, now))
       } catch (error) {
-        onError(error)  // Raise the onError event
         await processResponse(tree)
+        onError(error)  // Raise the onError event
       }
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,7 @@ export let ContextTree = _.curry(
     let {
       markForUpdate,
       markLastUpdate,
-      prepForUpdate,
-      resetUpdate,
+      prepForUpdate
     } = traversals(extend)
 
     let processEvent = event => path =>

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ export let ContextTree = _.curry(
         await processResponse(await service(dto, now))
       } catch (error) {
         onError(error)  // Raise the onError event
-        resetUpdate(tree)  // Reset the tree so there are no `updating` flags on etc
+        await processResponse(tree)
       }
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export let ContextTree = _.curry(
     extend = _.over([extend, (a, b) => TreeInstance.onChange(a, b)])
 
     // Getting the Traversals
-    let { markForUpdate, markLastUpdate, prepForUpdate } = traversals(extend)
+    let { markForUpdate, markLastUpdate, prepForUpdate, resetUpdate } = traversals(extend)
 
     let processEvent = event => path =>
       _.flow(
@@ -125,8 +125,9 @@ export let ContextTree = _.curry(
       prepForUpdate(tree)
       try {
         await processResponse(await service(dto, now))
-      } catch (e) {
-        onError(e)
+      } catch (error) {
+        onError(error)  // Raise the onError event
+        resetUpdate(tree)  // Reset the tree so there are no `updating` flags on etc
       }
     })
 
@@ -135,7 +136,6 @@ export let ContextTree = _.curry(
       data = _.isEmpty(data.data) ? data : data.data
       let { error } = data
       if (error) extend(tree, { error })
-
       await Promise.all(
         F.mapIndexed(async (node, path) => {
           let target = flat[path]

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ export let ContextTree = _.curry(
         await processResponse(await service(dto, now))
       } catch (error) {
         await processResponse(tree)
-        onError(error)  // Raise the onError event
+        onError(error) // Raise the onError event
       }
     })
 

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -26,4 +26,17 @@ export default extend => ({
       })
     }
   }),
+  resetUpdate: Tree.walk(child => {
+    if(child.markForUpdate || child.updating) {
+      extend(child, {
+        updating: false,
+        markedForUpdate: false,
+      })
+      try {
+        child.updatingDeferred.resolve()
+      } catch (e) {
+        console.error(`resetUpdate failed for: ${child.key}`)
+      }
+    }
+  }),
 })

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -26,17 +26,4 @@ export default extend => ({
       })
     }
   }),
-  resetUpdate: Tree.walk(child => {
-    if(child.markForUpdate || child.updating) {
-      extend(child, {
-        updating: false,
-        markedForUpdate: false,
-      })
-      try {
-        child.updatingDeferred.resolve()
-      } catch (e) {
-        console.error(`resetUpdate failed for: ${child.key}`)
-      }
-    }
-  }),
 })

--- a/test/index.js
+++ b/test/index.js
@@ -448,7 +448,6 @@ let AllTests = ContextureClient => {
       throw 'service error!'
     })
 
-    let spy = sinon.spy()
     let Tree = ContextureClient(
       {
         service,

--- a/test/index.js
+++ b/test/index.js
@@ -427,9 +427,52 @@ let AllTests = ContextureClient => {
     let step1 = Tree.mutate(['root', 'filter'], {
       values: ['a'],
     })
-    await Promise.delay(100)
+    await Promise.delay(20)
     await Promise.resolve(step1)
     expect(spy).to.have.callCount(1)
+  })
+  it('onError tree should be back to normal - no updating flags etc', async () => {
+    let service = sinon.spy(async () => {
+      throw 'service error!'
+    })
+    let spy = sinon.spy()
+    let onError = () => spy()
+    let tree = ContextureClient(
+      {
+        debounce: 0,
+        service,
+        types: {
+          facet: {
+            reactors: {
+              values: 'others',
+            },
+          },
+        },
+        onError
+      },
+      {
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'a',
+            type: 'facet',
+          },
+          {
+            key: 'b',
+            type: 'results',
+          },
+        ],
+      }
+    )
+    let step1 = tree.mutate(['root', 'a'], { values: [1] })
+    await Promise.delay(5)
+    await Promise.resolve(step1)
+    expect(spy).to.have.callCount(1)
+    let node = tree.getNode(['root', 'b'])
+    expect(node.updating).to.be.false
+    await node.updatingPromise
+    expect(node.updating).to.be.false
   })
   it('should throw when the service crashes', async () => {
     let tree = {

--- a/test/index.js
+++ b/test/index.js
@@ -410,7 +410,7 @@ let AllTests = ContextureClient => {
       ],
     }
     let service = sinon.spy(async () => {
-      throw 'service error'
+      throw 'service error!'
     })
 
     let spy = sinon.spy()
@@ -430,6 +430,40 @@ let AllTests = ContextureClient => {
     await Promise.delay(100)
     await Promise.resolve(step1)
     expect(spy).to.have.callCount(1)
+  })
+  it('should throw when the service crashes', async () => {
+    let tree = {
+      key: 'root',
+      join: 'and',
+      children: [{
+        key: 'filter',
+        type: 'facet',
+      },
+      {
+        key: 'results',
+        type: 'results',
+      }],
+    }
+    let service = sinon.spy(async () => {
+      throw 'service error!'
+    })
+
+    let spy = sinon.spy()
+    let Tree = ContextureClient(
+      {
+        service,
+        debounce: 1
+      },
+      tree
+    )
+    try {
+      await Tree.mutate(['root', 'filter'], {
+        values: ['a'],
+      })
+    } catch (e) {
+      expect(e).to.equal('service error!')
+      return
+    }
   })
   it('should support custom type reactors', async () => {
     let service = sinon.spy(mockService())


### PR DESCRIPTION
On service error we raise the `onError` but leave the tree post `prepForUpdate` as is with all the `updating` flags being set to true. We reset them via `resetUpdate` to be back to normal post service exception. This way the UI should automatically reset as well.