### PR TITLE
Handle the empty values better with subquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.26.2
+* Handle better empty values in sourceTree with subQuery
+
 # 2.26.1
 * Add custom autoKey function for terms_stats type (uses `key_field` and `value_field` instead of `field`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/subquery.js
+++ b/src/subquery.js
@@ -49,7 +49,9 @@ export default _.curry(
     sourceNode.afterSearch = () =>
       _.flow(
         mapSubqueryValues,
-        targetTree.mutate(targetPath)
+        _.get('tree.hasValue', sourceTree)
+          ? targetTree.mutate(targetPath)
+          : targetTree.clear(targetPath)
       )(sourceNode, targetNode, types)
   }
 )

--- a/src/subquery.js
+++ b/src/subquery.js
@@ -49,6 +49,8 @@ export default _.curry(
     sourceNode.afterSearch = () =>
       _.flow(
         mapSubqueryValues,
+        // If the sourceTree has no values at all clear the targetTree, otherwise mutate with the new values.
+        // This is needed in the cases where the intial values are removed and there are no values in the source tree anymore.
         _.get('tree.hasValue', sourceTree)
           ? targetTree.mutate(targetPath)
           : targetTree.clear(targetPath)

--- a/test/index.js
+++ b/test/index.js
@@ -1072,10 +1072,9 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).markedForUpdate).to.be.true
 
     await promise
-    expect(sourceTree.getNode(['innerRoot', 'c']).context.options).to.deep.equal([
-      { name: 1 },
-      { name: 2 },
-    ])
+    expect(
+      sourceTree.getNode(['innerRoot', 'c']).context.options
+    ).to.deep.equal([{ name: 1 }, { name: 2 }])
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([1, 2])
 
     // Mutate on sourceTree will await the Subquery into targetTree
@@ -1138,7 +1137,9 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).markedForUpdate).to.be.true
 
     await promise
-    expect(sourceTree.getNode(['innerRoot', 'c']).context.options).to.deep.equal([])
+    expect(
+      sourceTree.getNode(['innerRoot', 'c']).context.options
+    ).to.deep.equal([])
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([])
 
     // Mutate on sourceTree will await the Subquery into targetTree

--- a/test/index.js
+++ b/test/index.js
@@ -1052,38 +1052,97 @@ let AllTests = ContextureClient => {
     }
     let Tree = ContextureClient({ debounce: 1, service, types })
 
-    let tree1 = Tree({
+    let sourceTree = Tree({
       key: 'innerRoot',
       join: 'and',
       children: [{ key: 'c', type: 'facet' }, { key: 'd', type: 'facet' }],
     })
-    let tree2 = Tree({
+    let targetTree = Tree({
       key: 'root',
       join: 'and',
       children: [{ key: 'a', type: 'facet' }, { key: 'b', type: 'results' }],
     })
 
-    // subquery(types, tree2, ['root', 'a'], tree1, ['innerRoot', 'c'])
-    tree2.subquery(['root', 'a'], tree1, ['innerRoot', 'c'])
-    let promise = tree1.mutate(['innerRoot', 'd'], { values: ['test'] })
+    // subquery(types, targetTree, ['root', 'a'], sourceTree, ['innerRoot', 'c'])
+    targetTree.subquery(['root', 'a'], sourceTree, ['innerRoot', 'c'])
+    let promise = sourceTree.mutate(['innerRoot', 'd'], { values: ['test'] })
 
     // Expect the toNode to be marked for update immediately
     await Promise.delay(1)
-    expect(tree2.getNode(['root', 'a']).markedForUpdate).to.be.true
+    expect(targetTree.getNode(['root', 'a']).markedForUpdate).to.be.true
 
     await promise
-    expect(tree1.getNode(['innerRoot', 'c']).context.options).to.deep.equal([
+    expect(sourceTree.getNode(['innerRoot', 'c']).context.options).to.deep.equal([
       { name: 1 },
       { name: 2 },
     ])
-    expect(tree2.getNode(['root', 'a']).values).to.deep.equal([1, 2])
+    expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([1, 2])
 
-    // Mutate on tree1 will await the Subquery into tree2
+    // Mutate on sourceTree will await the Subquery into targetTree
     expect(spy).to.have.callCount(2)
 
-    expect(tree2.getNode(['root', 'b']).markedForUpdate).to.be.false
-    expect(tree2.getNode(['root', 'b']).updating).to.be.false
-    expect(tree2.getNode(['root', 'b']).context.count).to.equal(1)
+    expect(targetTree.getNode(['root', 'b']).markedForUpdate).to.be.false
+    expect(targetTree.getNode(['root', 'b']).updating).to.be.false
+    expect(targetTree.getNode(['root', 'b']).context.count).to.equal(1)
+  })
+  it('should support subquery clearing target tree', async () => {
+    let spy = sinon.spy(
+      mockService({
+        mocks({ key, type }) {
+          if (type === 'facet')
+            return {
+              options: {
+                c: [],
+                a: [{ name: 3 }, { name: 4 }],
+              }[key],
+            }
+          if (type === 'results')
+            return {
+              count: 1,
+              results: [{ title: 'some result' }],
+            }
+        },
+      })
+    )
+    let service = addDelay(10, spy)
+    let types = {
+      facet: {
+        reactors: { values: 'others' },
+        subquery: {
+          useValues: x => ({ values: x }),
+          getValues: x => _.map('name', x.context.options),
+        },
+        defaults: {
+          context: {
+            options: [],
+          },
+        },
+      },
+    }
+    let Tree = ContextureClient({ debounce: 1, service, types })
+
+    let sourceTree = Tree({
+      key: 'innerRoot',
+      join: 'and',
+      children: [{ key: 'c', type: 'facet' }, { key: 'd', type: 'facet' }],
+    })
+    let targetTree = Tree({
+      key: 'root',
+      join: 'and',
+      children: [{ key: 'a', type: 'facet', values: [] }],
+    })
+
+    targetTree.subquery(['root', 'a'], sourceTree, ['innerRoot', 'c'])
+    let promise = sourceTree.mutate(['innerRoot', 'd'], { values: ['test'] })
+    await Promise.delay(1)
+    expect(targetTree.getNode(['root', 'a']).markedForUpdate).to.be.true
+
+    await promise
+    expect(sourceTree.getNode(['innerRoot', 'c']).context.options).to.deep.equal([])
+    expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([])
+
+    // Mutate on sourceTree will await the Subquery into targetTree
+    expect(spy).to.have.callCount(2)
   })
   it('should respect disableAutoUpdate', async () => {
     let service = sinon.spy(mockService())


### PR DESCRIPTION
In regards to https://github.com/smartprocure/bid-search/issues/3500

In the case where the source tree has no values we should not `mutate` but `clear` the target node.