### PR TITLE
Observe Tree Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.26.3
+* Call `initObject` on `TreeInstance`. In the mobx case, this should allow observing tree instance properties like `disableAutoUpdate`
+
 # 2.26.2
 * Handle better empty values in sourceTree with subQuery
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following config options are available:
 | onResult          | (path, response, target) => {} |  _.noop      | A hook to capture when the client updates a node with results from the server. Can be modified at run time by reassigning the property on a tree instance. |
 | debug             | boolean                        | false        | Debug mode will log all dispatched events and generally help debugging |
 | extend            | function                       | F.extendOn   | Used to mutate nodes internally |
-| initObject        | function                       | _.identity   | Called on the tree at initialization and on payloads before add. With `mobx`, this would be `observable` |
+| initObject        | function                       | _.identity   | Called on the tree (and the "TreeInstance" return value of the client) at initialization and on payloads before add. With `mobx`, this would be `observable` |
 | snapshot          | function                       | _.cloneDeep  | Used to take snapshots |
 | disableAutoUpdate | boolean                        | false        | Will disable automatically triggering updates at the end of dispatches, except for events that affect their target node. This is useful for a search button use case, similar to pausing the entire tree but always allowing through specific changes. This is typically used with the `triggerUpdate` action to kick off a dispatch that will update everything `markedForUpdate`. Can be changed at run time. | 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ export let ContextTree = _.curry(
       initObject,
     }
 
-    let TreeInstance = {
+    let TreeInstance = initObject({
       serialize: () => serialize(snapshot(tree), {}),
       tree,
       ...actionProps,
@@ -179,7 +179,7 @@ export let ContextTree = _.curry(
       onResult,
       onChange,
       disableAutoUpdate,
-    }
+    })
 
     TreeInstance.addActions(actions)
     TreeInstance.lens = lens(TreeInstance)

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -411,4 +411,23 @@ describe('usage with mobx should generally work', () => {
     tree.children.push(observableNode)
     expect(tree.children[2]).to.equal(observableNode)
   })
+  it.only('should support observing disableAutoUpdate', () => {
+    service.reset()
+    let reactor = sinon.spy()
+    let tree = ContextureMobx({ service, debounce: 1 })({
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'filter 1',
+          type: 'facet',
+          field: 'facetfield',
+          value: 'some value',
+        },
+      ],
+    })
+    reaction(() => tree.disableAutoUpdate, reactor)
+    tree.disableAutoUpdate = true
+    expect(reactor).to.have.callCount(1)
+  })
 })

--- a/test/mobx.js
+++ b/test/mobx.js
@@ -411,7 +411,7 @@ describe('usage with mobx should generally work', () => {
     tree.children.push(observableNode)
     expect(tree.children[2]).to.equal(observableNode)
   })
-  it.only('should support observing disableAutoUpdate', () => {
+  it('should support observing disableAutoUpdate', () => {
     service.reset()
     let reactor = sinon.spy()
     let tree = ContextureMobx({ service, debounce: 1 })({


### PR DESCRIPTION
In the mobx case, if you try to make a contexture tree observable, the client won't see the changes. The underlying issue is documented in this runkit: https://runkit.com/daedalus28/mobx-reference-issues

However, changing `disableAutoUpdate` should be able to be observed in the mobx scenario. All we need to do to remedy this is make sure that we init the returned `TreeInstance` with `initObject` (provided by the `mobxAdapter` as config) so that the client retains the observable instance.

Complete with unit tests and everything 😄 Fun fact - with this PR we now have *100* test cases in `contecxture-client` 🎉 