### PR TITLE
feature/121 - fix subquery afterSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.28.1
+* Fix an issue updating the target search from a subquery
+
 # 2.28.0
 * Add `processResponseNode` to support intermediate partial results from the server
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/subquery.js
+++ b/src/subquery.js
@@ -54,7 +54,7 @@ export default _.curry(
         // This is needed in the cases where the intial values are removed and there are no values in the source tree anymore.
         _.get('tree.hasValue', sourceTree)
           ? targetTree.mutate(targetPath)
-          : targetTree.clear(targetPath)
+          : () => targetTree.clear(targetPath)
       )(sourceNode, targetNode, types)
   }
 )


### PR DESCRIPTION
Fixes #121 

### Description
* clear unlike mutate returns a promise when given one argument -- just need to return a function that calls that