### PR TITLE
[WIP] Feature/123 - bindSearches util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.29.0
+* Implement bindSearches util for multi-tree searches
+
 # 2.28.1
 * Fix an issue updating the target search from a subquery
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ Here's an example implementation, using the `facet` example type:
 
 If you pass `mapSubqueryValues` as the last parameter, you can ignore the `types` parameter. It's signature is `(sourceNode, targetNode, types) => deltasForTargetNodeMutate`.
 
+#### bindSearches
+Sets up multiple subqueries among a set of instantiated searches as specified by a passed config blob.
+
 ##### Loading Indicators
 A change to the source node in a subquery will immediately mark the target node as marked for update, but will not execute it's search until after the source node has results and the debounce time passes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.28.1",
+  "version": "2.28.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -117,8 +117,8 @@ export let bindSearches = ({
                 sourceSearch.tree.schema,
                 _.get('targetSearches', targetSearchSourceNode)
               )
-                ? // unset any of the current values because we want any 3rd party trees to know about this update
-                  [sourceSearch.tree.schema]
+                // unset any current values because we want any 3rd party trees to know about this update
+                ? [sourceSearch.tree.schema]
                 : [],
               paused: false,
             }),

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -117,8 +117,8 @@ export let bindSearches = ({
                 sourceSearch.tree.schema,
                 _.get('targetSearches', targetSearchSourceNode)
               )
-                // unset any current values because we want any 3rd party trees to know about this update
-                ? [sourceSearch.tree.schema]
+                ? // unset any current values because we want any 3rd party trees to know about this update
+                  [sourceSearch.tree.schema]
                 : [],
               paused: false,
             }),

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -1,0 +1,87 @@
+import _ from 'lodash/fp'
+import F from 'futil-js'
+
+let sourceKey = source => `tree-binding-source-${source.field}`
+let targetKey = search => `tree-binding-destination-${_.get('tree.schema', search)}`
+
+let getSearchSourceNodes = _.flow(
+  _.get('tree.children'),
+  _.filter(node => _.includes('tree-binding-source-', _.get('key', node))),
+)
+
+export let bindSearches = ({
+  searches = {},
+  subqueries = []
+}) => {
+  _.each(({ source, targets }) => {
+    let sourceSearch = searches[source.search]
+    let targetSchemas = _.map(target => _.get('tree.schema', searches[target.search]), targets)
+
+    sourceSearch.add(['root'], {
+      key: sourceKey(source),
+      type: 'facet',
+      field: source.field,
+      size: 1000000,
+      isMongoId: true,
+      paused: true,
+      suppressUpdates: targetSchemas,
+      targetSearches: targetSchemas,
+    })
+
+    let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])
+
+    let sourceSearchMaintainSuppressionPaths = _.concat(
+      _.flow(
+        _.filter(subquery => subquery.source.search === source.search),
+        _.map(subquery => ['root', sourceKey(subquery.source)])
+      )(subqueries),
+      _.flow(
+        _.flatMap(subquery => _.map(target => ({...target, sourceSearch: subquery.source.search }), subquery.targets)),
+        _.filter(target => target.search === source.search),
+        _.map(target => ['root', targetKey(searches[target.sourceSearch])])
+      )(subqueries),
+    )
+
+    sourceSearch.defaultMutate = sourceSearch.defaultMutate || sourceSearch.mutate
+    sourceSearch.mutate = (path, mutation) => {
+      if (F.cascade(['values', 'value', 'options'], mutation) && !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)) {
+        let sourceSearchSourcePaths = _.flow(
+          getSearchSourceNodes,
+          _.map(node => ['root', node.key])
+        )(sourceSearch)
+        _.map(sourceSearchSourcePath => sourceSearch.defaultMutate(sourceSearchSourcePath, { suppressUpdates: [], paused: false }), sourceSearchSourcePaths)
+      }
+      sourceSearch.defaultMutate(path, mutation)
+    }
+
+    let targetSearches = _.map(target => {
+      let targetSearch = searches[target.search]
+      targetSearch.add(['root'], {
+        key: targetKey(sourceSearch),
+        type: 'facet',
+        field: target.field,
+        size: 1000000,
+        isMongoId: true
+      })
+      return targetSearch
+    }, targets)
+
+    sourceNode.afterSearch = () => {
+      let targetSearchesToUpdate = _.reject(targetSearch => _.includes(targetSearch.tree.schema, sourceNode.suppressUpdates), targetSearches)
+
+      _.each(targetSearch => {
+        _.each(targetSearchSourceNode => targetSearch.mutate(['root', targetSearchSourceNode.key], {
+          suppressUpdates: _.includes(sourceSearch.tree.schema, _.get('targetSearches', targetSearchSourceNode)) ? [sourceSearch.tree.schema] : [],
+          paused: false
+        }), getSearchSourceNodes(targetSearch))
+
+        let foreignTargetPath = ['root', targetKey(sourceSearch)]
+        if (sourceSearch.tree.hasValue) {
+          targetSearch.mutate(foreignTargetPath, { values: _.map('name', sourceNode.context.options) })
+        } else {
+          targetSearch.clear(foreignTargetPath)
+        }
+      }, targetSearchesToUpdate)
+    }
+  }, subqueries)
+}

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -32,7 +32,6 @@ export let bindSearches = ({
       paused: true,
       suppressUpdates: targetSchemas,
       targetSearches: targetSchemas,
-      treeBindingSource: true,
     })
 
     let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -108,8 +108,8 @@ export let bindSearches = ({
       )
 
       _.each(targetSearch => {
-        // now, for each target tree that we're going to pass values to, we need to tell it to ignore
-        // subsequent updates from the current source tree (until this suppression is cleared by the wrapped tree.mutate)
+        // now, for each target tree that we're going to pass values to, we need to tell it not to
+        // send updates to current source tree (until this suppression is cleared by its own wrapped tree.mutate)
         _.each(
           targetSearchSourceNode =>
             targetSearch.mutate(['root', targetSearchSourceNode.key], {

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -12,7 +12,7 @@ let getSearchSourceNodes = _.flow(
 
 export let bindSearches = ({
   searches = {}, // instantiated contexture-client searches
-  subqueries = [], // [{ source: { search, field }, targets: [{ search, field }] }]
+  subqueries = [], // [{ source: { search, field, isMongoId }, targets: [{ search, field, isMongoId }] }]
 }) => {
   _.each(({ source, targets }) => {
     let sourceSearch = searches[source.search]
@@ -57,13 +57,13 @@ export let bindSearches = ({
       )(subqueries)
     )
 
-    // wrap the default tree.mutate so we can inspect all mutations and re-enable updates
+    // wrap the default tree.mutate so we can inspect all mutations and re-enable updates to
     // other trees when the current tree receives updates from the user or other trees
     sourceSearch.defaultMutate =
       sourceSearch.defaultMutate || sourceSearch.mutate
     sourceSearch.mutate = (path, mutation) => {
       // if we get a real change to value, values or options on a non-ignored path, clear
-      // update supporession to the neighboring trees
+      // update suppression to the neighboring trees
       if (
         F.cascade(['values', 'value', 'options'], mutation) &&
         !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -117,8 +117,8 @@ export let bindSearches = ({
                 sourceSearch.tree.schema,
                 _.get('targetSearches', targetSearchSourceNode)
               )
-                // unset any of the current values because we want any 3rd party trees to know about this update
-                ? [sourceSearch.tree.schema]
+                ? // unset any of the current values because we want any 3rd party trees to know about this update
+                  [sourceSearch.tree.schema]
                 : [],
               paused: false,
             }),

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -117,8 +117,7 @@ export let bindSearches = ({
                 sourceSearch.tree.schema,
                 _.get('targetSearches', targetSearchSourceNode)
               )
-                ? // unset any current values because we want any 3rd party trees to know about this update
-                  [sourceSearch.tree.schema]
+                ? [sourceSearch.tree.schema]  // unset any current values because we want any 3rd party trees to know about this update
                 : [],
               paused: false,
             }),

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -28,7 +28,7 @@ export let bindSearches = ({
       type: 'facet',
       field: source.field,
       size: 1000000,
-      isMongoId: true,
+      ...(source.isMongoId ? { isMongoId: true } : {}),
       paused: true,
       suppressUpdates: targetSchemas,
       targetSearches: targetSchemas,
@@ -94,7 +94,7 @@ export let bindSearches = ({
         type: 'facet',
         field: target.field,
         size: 1000000,
-        isMongoId: true,
+        ...(target.isMongoId ? { isMongoId: true } : {}),
       })
       return targetSearch
     }, targets)

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -100,7 +100,7 @@ export let bindSearches = ({
 
     sourceNode.afterSearch = () => {
       // when we get search results on a source node, first remove anything on its suppressUpdates list
-      // from its total list of subquery targets
+      // from its total list of subquery targets to get a list of target searches to update
       let targetSearchesToUpdate = _.reject(
         targetSearch =>
           _.includes(targetSearch.tree.schema, sourceNode.suppressUpdates),

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -10,78 +10,97 @@ let getSearchSourceNodes = _.flow(
 )
 
 export let bindSearches = ({
-  searches = {},
-  subqueries = []
-}) => {
-  _.each(({ source, targets }) => {
-    let sourceSearch = searches[source.search]
-    let targetSchemas = _.map(target => _.get('tree.schema', searches[target.search]), targets)
-
-    sourceSearch.add(['root'], {
-      key: sourceKey(source),
-      type: 'facet',
-      field: source.field,
-      size: 1000000,
-      isMongoId: true,
-      paused: true,
-      suppressUpdates: targetSchemas,
-      targetSearches: targetSchemas
-    })
-
-    let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])
-
-    let sourceSearchMaintainSuppressionPaths = _.concat(
-      _.flow(
-        _.filter(subquery => subquery.source.search === source.search),
-        _.map(subquery => ['root', sourceKey(subquery.source)])
-      )(subqueries),
-      _.flow(
-        _.flatMap(subquery => _.map(target => ({...target, sourceSearch: subquery.source.search }), subquery.targets)),
-        _.filter(target => target.search === source.search),
-        _.map(target => ['root', targetKey(searches[target.sourceSearch])])
-      )(subqueries),
-    )
-
-    sourceSearch.defaultMutate = sourceSearch.defaultMutate || sourceSearch.mutate
-    sourceSearch.mutate = (path, mutation) => {
-      if (F.cascade(['values', 'value', 'options'], mutation) && !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)) {
-        let sourceSearchSourcePaths = _.flow(
-          getSearchSourceNodes,
-          _.map(node => ['root', node.key])
-        )(sourceSearch)
-        _.map(sourceSearchSourcePath => sourceSearch.defaultMutate(sourceSearchSourcePath, { suppressUpdates: [], paused: false }), sourceSearchSourcePaths)
-      }
-      sourceSearch.defaultMutate(path, mutation)
-    }
-
-    let targetSearches = _.map(target => {
-      let targetSearch = searches[target.search]
-      targetSearch.add(['root'], {
-        key: targetKey(sourceSearch),
+    searches = {}, // instantiated contexture-client searches
+    subqueries = [] // [{ source: { search, field }, targets: [{ search, field }] }]
+  }) => {
+    _.each(({ source, targets }) => {
+      let sourceSearch = searches[source.search]
+      let targetSchemas = _.map(target => _.get('tree.schema', searches[target.search]), targets)
+  
+      // add the subquery source node with bookkeeping arrays for which subqueries
+      // exist (targetSearches) and which are currently inactive (suppressUpdates)
+      sourceSearch.add(['root'], {
+        key: sourceKey(source),
         type: 'facet',
-        field: target.field,
+        field: source.field,
         size: 1000000,
-        isMongoId: true
+        isMongoId: true,
+        paused: true,
+        suppressUpdates: targetSchemas,
+        targetSearches: targetSchemas,
+        treeBindingSource: true
       })
-      return targetSearch
-    }, targets)
-
-    sourceNode.afterSearch = () => {
-      let targetSearchesToUpdate = _.reject(targetSearch => _.includes(targetSearch.tree.schema, sourceNode.suppressUpdates), targetSearches)
-
-      _.each(targetSearch => {
-        _.each(targetSearchSourceNode => targetSearch.mutate(['root', targetSearchSourceNode.key], {
-          suppressUpdates: _.includes(sourceSearch.tree.schema, _.get('targetSearches', targetSearchSourceNode)) ? [sourceSearch.tree.schema] : [],
-          paused: false
-        }), getSearchSourceNodes(targetSearch))
-
-        let foreignTargetPath = ['root', targetKey(sourceSearch)]
-        if (sourceSearch.tree.hasValue) {
-          targetSearch.mutate(foreignTargetPath, { values: _.map('name', sourceNode.context.options) })
-        } else {
-          targetSearch.clear(foreignTargetPath)
+  
+      let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])
+  
+      // calcluate all source and target node paths on the tree for the whole bindSearches blob
+      // now so that we won't have to lookup node.treeBindingSource in tree.mutate below
+      // updates to these nodes will be ignored except in one cases handled below in node.afterSearch
+      let sourceSearchMaintainSuppressionPaths = _.concat(
+        _.flow(
+          _.filter(subquery => subquery.source.search === source.search),
+          _.map(subquery => ['root', sourceKey(subquery.source)])
+        )(subqueries),
+        _.flow(
+          _.flatMap(subquery => _.map(target => ({...target, sourceSearch: subquery.source.search }), subquery.targets)),
+          _.filter(target => target.search === source.search),
+          _.map(target => ['root', targetKey(searches[target.sourceSearch])])
+        )(subqueries),
+      )
+  
+      // wrap the default tree.mutate so we can inspect all mutations and re-enable updates
+      // other trees when the current tree receives updates from the user or other trees
+      sourceSearch.defaultMutate = sourceSearch.defaultMutate || sourceSearch.mutate
+      sourceSearch.mutate = (path, mutation) => {
+        // if we get a real change to value, values or options on a non-ignored path, clear
+        // update supporession to the neigboring trees
+        if (F.cascade(['values', 'value', 'options'], mutation) && !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)) {
+          let sourceSearchSourcePaths = _.flow(
+            getSearchSourceNodes,
+            _.map(node => ['root', node.key])
+          )(sourceSearch)
+          _.map(sourceSearchSourcePath => sourceSearch.defaultMutate(sourceSearchSourcePath, { suppressUpdates: [], paused: false }), sourceSearchSourcePaths)
         }
-      }, targetSearchesToUpdate)
-    }
-  }, subqueries)
-}
+        // pass the mutation through to the original tree.mutate
+        sourceSearch.defaultMutate(path, mutation)
+      }
+  
+      // add a subquery target node for each target search specified in the blob
+      // for the current source node
+      let targetSearches = _.map(target => {
+        let targetSearch = searches[target.search]
+        targetSearch.add(['root'], {
+          key: targetKey(sourceSearch),
+          type: 'facet',
+          field: target.field,
+          size: 1000000,
+          isMongoId: true
+        })
+        return targetSearch
+      }, targets)
+  
+      sourceNode.afterSearch = () => {
+        // when we get search results on a source node, first remove anything on its suppressUpdates list
+        // from its total list of subquery targets 
+        let targetSearchesToUpdate = _.reject(targetSearch => _.includes(targetSearch.tree.schema, sourceNode.suppressUpdates), targetSearches)
+  
+        _.each(targetSearch => {
+          // now, for each target tree that we're going to pass values to, we need to tell it to ignore
+          // subsequent updates from the current source tree (until this suppression is cleared by the wrapped tree.mutate)
+          _.each(targetSearchSourceNode => targetSearch.mutate(['root', targetSearchSourceNode.key], {
+            suppressUpdates: _.includes(sourceSearch.tree.schema, _.get('targetSearches', targetSearchSourceNode)) ? [sourceSearch.tree.schema] : [],
+            paused: false
+          }), getSearchSourceNodes(targetSearch))
+  
+          // set source option names as the target facet values or cleae the target as appropriate
+          let foreignTargetPath = ['root', targetKey(sourceSearch)]
+          if (sourceSearch.tree.hasValue) {
+            targetSearch.mutate(foreignTargetPath, { values: _.map('name', sourceNode.context.options) })
+          } else {
+            targetSearch.clear(foreignTargetPath)
+          }
+        }, targetSearchesToUpdate)
+      }
+    }, subqueries)
+  }
+  

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -2,105 +2,139 @@ import _ from 'lodash/fp'
 import F from 'futil-js'
 
 let sourceKey = source => `tree-binding-source-${source.field}`
-let targetKey = search => `tree-binding-destination-${_.get('tree.schema', search)}`
+let targetKey = search =>
+  `tree-binding-destination-${_.get('tree.schema', search)}`
 
 let getSearchSourceNodes = _.flow(
   _.get('tree.children'),
-  _.filter(_.has('targetSearches')),
+  _.filter(_.has('targetSearches'))
 )
 
 export let bindSearches = ({
-    searches = {}, // instantiated contexture-client searches
-    subqueries = [] // [{ source: { search, field }, targets: [{ search, field }] }]
-  }) => {
-    _.each(({ source, targets }) => {
-      let sourceSearch = searches[source.search]
-      let targetSchemas = _.map(target => _.get('tree.schema', searches[target.search]), targets)
-  
-      // add the subquery source node with bookkeeping arrays for which subqueries
-      // exist (targetSearches) and which are currently inactive (suppressUpdates)
-      sourceSearch.add(['root'], {
-        key: sourceKey(source),
+  searches = {}, // instantiated contexture-client searches
+  subqueries = [], // [{ source: { search, field }, targets: [{ search, field }] }]
+}) => {
+  _.each(({ source, targets }) => {
+    let sourceSearch = searches[source.search]
+    let targetSchemas = _.map(
+      target => _.get('tree.schema', searches[target.search]),
+      targets
+    )
+
+    // add the subquery source node with bookkeeping arrays for which subqueries
+    // exist (targetSearches) and which are currently inactive (suppressUpdates)
+    sourceSearch.add(['root'], {
+      key: sourceKey(source),
+      type: 'facet',
+      field: source.field,
+      size: 1000000,
+      isMongoId: true,
+      paused: true,
+      suppressUpdates: targetSchemas,
+      targetSearches: targetSchemas,
+      treeBindingSource: true,
+    })
+
+    let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])
+
+    // calcluate all source and target node paths on the tree for the whole bindSearches blob
+    // now so that we won't have to lookup node.treeBindingSource in tree.mutate below
+    // updates to these nodes will be ignored except in one cases handled below in node.afterSearch
+    let sourceSearchMaintainSuppressionPaths = _.concat(
+      _.flow(
+        _.filter(subquery => subquery.source.search === source.search),
+        _.map(subquery => ['root', sourceKey(subquery.source)])
+      )(subqueries),
+      _.flow(
+        _.flatMap(subquery =>
+          _.map(
+            target => ({ ...target, sourceSearch: subquery.source.search }),
+            subquery.targets
+          )
+        ),
+        _.filter(target => target.search === source.search),
+        _.map(target => ['root', targetKey(searches[target.sourceSearch])])
+      )(subqueries)
+    )
+
+    // wrap the default tree.mutate so we can inspect all mutations and re-enable updates
+    // other trees when the current tree receives updates from the user or other trees
+    sourceSearch.defaultMutate =
+      sourceSearch.defaultMutate || sourceSearch.mutate
+    sourceSearch.mutate = (path, mutation) => {
+      // if we get a real change to value, values or options on a non-ignored path, clear
+      // update supporession to the neigboring trees
+      if (
+        F.cascade(['values', 'value', 'options'], mutation) &&
+        !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)
+      ) {
+        let sourceSearchSourcePaths = _.flow(
+          getSearchSourceNodes,
+          _.map(node => ['root', node.key])
+        )(sourceSearch)
+        _.map(
+          sourceSearchSourcePath =>
+            sourceSearch.defaultMutate(sourceSearchSourcePath, {
+              suppressUpdates: [],
+              paused: false,
+            }),
+          sourceSearchSourcePaths
+        )
+      }
+      // pass the mutation through to the original tree.mutate
+      sourceSearch.defaultMutate(path, mutation)
+    }
+
+    // add a subquery target node for each target search specified in the blob
+    // for the current source node
+    let targetSearches = _.map(target => {
+      let targetSearch = searches[target.search]
+      targetSearch.add(['root'], {
+        key: targetKey(sourceSearch),
         type: 'facet',
-        field: source.field,
+        field: target.field,
         size: 1000000,
         isMongoId: true,
-        paused: true,
-        suppressUpdates: targetSchemas,
-        targetSearches: targetSchemas,
-        treeBindingSource: true
       })
-  
-      let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])
-  
-      // calcluate all source and target node paths on the tree for the whole bindSearches blob
-      // now so that we won't have to lookup node.treeBindingSource in tree.mutate below
-      // updates to these nodes will be ignored except in one cases handled below in node.afterSearch
-      let sourceSearchMaintainSuppressionPaths = _.concat(
-        _.flow(
-          _.filter(subquery => subquery.source.search === source.search),
-          _.map(subquery => ['root', sourceKey(subquery.source)])
-        )(subqueries),
-        _.flow(
-          _.flatMap(subquery => _.map(target => ({...target, sourceSearch: subquery.source.search }), subquery.targets)),
-          _.filter(target => target.search === source.search),
-          _.map(target => ['root', targetKey(searches[target.sourceSearch])])
-        )(subqueries),
+      return targetSearch
+    }, targets)
+
+    sourceNode.afterSearch = () => {
+      // when we get search results on a source node, first remove anything on its suppressUpdates list
+      // from its total list of subquery targets
+      let targetSearchesToUpdate = _.reject(
+        targetSearch =>
+          _.includes(targetSearch.tree.schema, sourceNode.suppressUpdates),
+        targetSearches
       )
-  
-      // wrap the default tree.mutate so we can inspect all mutations and re-enable updates
-      // other trees when the current tree receives updates from the user or other trees
-      sourceSearch.defaultMutate = sourceSearch.defaultMutate || sourceSearch.mutate
-      sourceSearch.mutate = (path, mutation) => {
-        // if we get a real change to value, values or options on a non-ignored path, clear
-        // update supporession to the neigboring trees
-        if (F.cascade(['values', 'value', 'options'], mutation) && !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)) {
-          let sourceSearchSourcePaths = _.flow(
-            getSearchSourceNodes,
-            _.map(node => ['root', node.key])
-          )(sourceSearch)
-          _.map(sourceSearchSourcePath => sourceSearch.defaultMutate(sourceSearchSourcePath, { suppressUpdates: [], paused: false }), sourceSearchSourcePaths)
+
+      _.each(targetSearch => {
+        // now, for each target tree that we're going to pass values to, we need to tell it to ignore
+        // subsequent updates from the current source tree (until this suppression is cleared by the wrapped tree.mutate)
+        _.each(
+          targetSearchSourceNode =>
+            targetSearch.mutate(['root', targetSearchSourceNode.key], {
+              suppressUpdates: _.includes(
+                sourceSearch.tree.schema,
+                _.get('targetSearches', targetSearchSourceNode)
+              )
+                ? [sourceSearch.tree.schema]
+                : [],
+              paused: false,
+            }),
+          getSearchSourceNodes(targetSearch)
+        )
+
+        // set source option names as the target facet values or cleae the target as appropriate
+        let foreignTargetPath = ['root', targetKey(sourceSearch)]
+        if (sourceSearch.tree.hasValue) {
+          targetSearch.mutate(foreignTargetPath, {
+            values: _.map('name', sourceNode.context.options),
+          })
+        } else {
+          targetSearch.clear(foreignTargetPath)
         }
-        // pass the mutation through to the original tree.mutate
-        sourceSearch.defaultMutate(path, mutation)
-      }
-  
-      // add a subquery target node for each target search specified in the blob
-      // for the current source node
-      let targetSearches = _.map(target => {
-        let targetSearch = searches[target.search]
-        targetSearch.add(['root'], {
-          key: targetKey(sourceSearch),
-          type: 'facet',
-          field: target.field,
-          size: 1000000,
-          isMongoId: true
-        })
-        return targetSearch
-      }, targets)
-  
-      sourceNode.afterSearch = () => {
-        // when we get search results on a source node, first remove anything on its suppressUpdates list
-        // from its total list of subquery targets 
-        let targetSearchesToUpdate = _.reject(targetSearch => _.includes(targetSearch.tree.schema, sourceNode.suppressUpdates), targetSearches)
-  
-        _.each(targetSearch => {
-          // now, for each target tree that we're going to pass values to, we need to tell it to ignore
-          // subsequent updates from the current source tree (until this suppression is cleared by the wrapped tree.mutate)
-          _.each(targetSearchSourceNode => targetSearch.mutate(['root', targetSearchSourceNode.key], {
-            suppressUpdates: _.includes(sourceSearch.tree.schema, _.get('targetSearches', targetSearchSourceNode)) ? [sourceSearch.tree.schema] : [],
-            paused: false
-          }), getSearchSourceNodes(targetSearch))
-  
-          // set source option names as the target facet values or cleae the target as appropriate
-          let foreignTargetPath = ['root', targetKey(sourceSearch)]
-          if (sourceSearch.tree.hasValue) {
-            targetSearch.mutate(foreignTargetPath, { values: _.map('name', sourceNode.context.options) })
-          } else {
-            targetSearch.clear(foreignTargetPath)
-          }
-        }, targetSearchesToUpdate)
-      }
-    }, subqueries)
-  }
-  
+      }, targetSearchesToUpdate)
+    }
+  }, subqueries)
+}

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -117,7 +117,7 @@ export let bindSearches = ({
                 sourceSearch.tree.schema,
                 _.get('targetSearches', targetSearchSourceNode)
               )
-                ? [sourceSearch.tree.schema]  // unset any current values because we want any 3rd party trees to know about this update
+                ? [sourceSearch.tree.schema] // unset any current values because we want any 3rd party trees to know about this update
                 : [],
               paused: false,
             }),

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -38,8 +38,8 @@ export let bindSearches = ({
     let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])
 
     // calcluate all source and target node paths on the tree for the whole bindSearches blob
-    // now so that we won't have to lookup node.treeBindingSource in tree.mutate below
-    // updates to these nodes will be ignored except in one cases handled below in node.afterSearch
+    // now so that we won't have to lookup node.targetSearches in tree.mutate below, which would slow the UI to a crawl.
+    // updates to these nodes will be ignored except as handled below in node.afterSearch
     let sourceSearchMaintainSuppressionPaths = _.concat(
       _.flow(
         _.filter(subquery => subquery.source.search === source.search),
@@ -63,7 +63,7 @@ export let bindSearches = ({
       sourceSearch.defaultMutate || sourceSearch.mutate
     sourceSearch.mutate = (path, mutation) => {
       // if we get a real change to value, values or options on a non-ignored path, clear
-      // update supporession to the neigboring trees
+      // update supporession to the neighboring trees
       if (
         F.cascade(['values', 'value', 'options'], mutation) &&
         !_.find(p => _.isEqual(p, path), sourceSearchMaintainSuppressionPaths)
@@ -125,7 +125,7 @@ export let bindSearches = ({
           getSearchSourceNodes(targetSearch)
         )
 
-        // set source option names as the target facet values or cleae the target as appropriate
+        // set source option names as the target facet values or clear the target as appropriate
         let foreignTargetPath = ['root', targetKey(sourceSearch)]
         if (sourceSearch.tree.hasValue) {
           targetSearch.mutate(foreignTargetPath, {

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -6,7 +6,7 @@ let targetKey = search => `tree-binding-destination-${_.get('tree.schema', searc
 
 let getSearchSourceNodes = _.flow(
   _.get('tree.children'),
-  _.filter(node => _.includes('tree-binding-source-', _.get('key', node))),
+  _.filter(_.has('targetSearches')),
 )
 
 export let bindSearches = ({
@@ -25,7 +25,7 @@ export let bindSearches = ({
       isMongoId: true,
       paused: true,
       suppressUpdates: targetSchemas,
-      targetSearches: targetSchemas,
+      targetSearches: targetSchemas
     })
 
     let sourceNode = sourceSearch.getNode(['root', sourceKey(source)])

--- a/src/bindSearches.js
+++ b/src/bindSearches.js
@@ -117,6 +117,7 @@ export let bindSearches = ({
                 sourceSearch.tree.schema,
                 _.get('targetSearches', targetSearchSourceNode)
               )
+                // unset any of the current values because we want any 3rd party trees to know about this update
                 ? [sourceSearch.tree.schema]
                 : [],
               paused: false,

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export {
   hasValue,
   mockService,
   subquery,
-  bindSearches
+  bindSearches,
 }
 
 export let ContextTree = _.curry(

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import exampleTypes from './exampleTypes'
 import lens from './lens'
 import mockService from './mockService'
 import subquery from './subquery'
+import bindSearches from './bindSearches'
 
 let mergeWith = _.mergeWith.convert({ immutable: false })
 
@@ -41,6 +42,7 @@ export {
   hasValue,
   mockService,
   subquery,
+  bindSearches
 }
 
 export let ContextTree = _.curry(


### PR DESCRIPTION
FIxes #123 

### Description
A revisit of the old "Cascades" from earlier days in the stack. 
* Pass the function some running searches and a JSON blob of specifying the from/to for the subqueries you want and it sets up those subqueries in an intelligent manner: if tree A updates tree B, tree B will refuse to update tree A until it gets an update from something other than tree A. 
* All bookkeeping is handled for setting up arbitrarily complicated nests of searches.
* currently only supports facet options -> facet values subqueries