### PR TITLE
feature/126 - add facet value labeling props to facet type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.29.0
+* support passig a second labelData argument to the `display` function used by Facet to display facet values
+
 # 2.28.1
 * Fix an issue updating the target search from a subquery
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.29.0
-* support passig a second labelData argument to the `display` function used by Facet to display facet values
+* support props required for foreign collection labels on facet types
 
 # 2.28.1
 * Fix an issue updating the target search from a subquery

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.28.1",
+  "version": "2.29.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -32,9 +32,11 @@ export default stampKey('type', {
       size: 'self',
       optionsFilter: 'self',
       sort: 'self',
-      valueLabelCollection: 'self',
-      valueLabelForeignField: 'self',
-      valueLabelFields: 'self',
+      lookup: {
+        collection: 'self',
+        foreignField: 'self',
+        fields: 'self',
+      },
     },
     defaults: {
       field: null,
@@ -45,9 +47,11 @@ export default stampKey('type', {
         options: [],
         cardinality: null,
       },
-      valueLabelCollection: null,
-      valueLabelForeignField: null,
-      valueLabelFields: null,
+      lookup: {
+        collection: null,
+        foreignField: null,
+        fields: null,
+      },
     },
     subquery: {
       useValues: x => ({ values: x }),

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -32,7 +32,7 @@ export default stampKey('type', {
       size: 'self',
       optionsFilter: 'self',
       sort: 'self',
-      lookup: {
+      label: {
         collection: 'self',
         foreignField: 'self',
         fields: 'self',
@@ -47,7 +47,7 @@ export default stampKey('type', {
         options: [],
         cardinality: null,
       },
-      lookup: {
+      label: {
         collection: null,
         foreignField: null,
         fields: null,

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -34,7 +34,7 @@ export default stampKey('type', {
       sort: 'self',
       valueLabelCollection: 'self',
       valueLabelForeignField: 'self',
-      valueLabelFields: 'self'
+      valueLabelFields: 'self',
     },
     defaults: {
       field: null,
@@ -47,7 +47,7 @@ export default stampKey('type', {
       },
       valueLabelCollection: null,
       valueLabelForeignField: null,
-      valueLabelFields: null
+      valueLabelFields: null,
     },
     subquery: {
       useValues: x => ({ values: x }),

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -32,6 +32,9 @@ export default stampKey('type', {
       size: 'self',
       optionsFilter: 'self',
       sort: 'self',
+      valueLabelCollection: 'self',
+      valueLabelForeignField: 'self',
+      valueLabelFields: 'self'
     },
     defaults: {
       field: null,
@@ -42,6 +45,9 @@ export default stampKey('type', {
         options: [],
         cardinality: null,
       },
+      valueLabelCollection: null,
+      valueLabelForeignField: null,
+      valueLabelFields: null
     },
     subquery: {
       useValues: x => ({ values: x }),

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -90,6 +90,11 @@ describe('usage with mobx should generally work', () => {
           values: ['a'],
           mode: 'include',
           filterOnly: true,
+          label: {
+            collection: null,
+            foreignField: null,
+            fields: null
+          },
           optionsFilter: '',
         },
         {

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -122,6 +122,11 @@ describe('usage with mobx should generally work', () => {
         cardinality: null,
       },
       metaHistory: [],
+      label: {
+        collection: null,
+        foreignField: null,
+        fields: null,
+      },
     })
     // should update contexts
     expect(Tree.getNode(['root', 'results']).updating).to.be.false
@@ -181,6 +186,11 @@ describe('usage with mobx should generally work', () => {
         options: [],
         cardinality: null,
       },
+      label: {
+        collection: null,
+        foreignField: null,
+        fields: null,
+      },
       metaHistory: [],
     })
     disposer()
@@ -235,6 +245,11 @@ describe('usage with mobx should generally work', () => {
       context: {},
       values: [],
       metaHistory: [],
+      label: {
+        collection: null,
+        foreignField: null,
+        fields: null,
+      },
     })
     expect(
       _.flow(
@@ -249,6 +264,11 @@ describe('usage with mobx should generally work', () => {
       path: ['root', 'newEmptyFilter'],
       values: [],
       metaHistory: [],
+      label: {
+        collection: null,
+        foreignField: null,
+        fields: null,
+      },
     })
 
     expect(

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -93,7 +93,7 @@ describe('usage with mobx should generally work', () => {
           label: {
             collection: null,
             foreignField: null,
-            fields: null
+            fields: null,
           },
           optionsFilter: '',
         },

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,11 @@ let AllTests = ContextureClient => {
             values: ['a'],
             filterOnly: true,
             optionsFilter: '',
+            label: {
+              collection: null,
+              foreignField: null,
+              fields: null
+            }
           },
           {
             key: 'results',
@@ -89,6 +94,11 @@ let AllTests = ContextureClient => {
             mode: 'include',
             values: ['a'],
             optionsFilter: '',
+            label: {
+              collection: null,
+              foreignField: null,
+              fields: null
+            }
           },
           {
             key: 'results',
@@ -120,6 +130,11 @@ let AllTests = ContextureClient => {
             mode: 'include',
             lastUpdateTime: now,
             optionsFilter: '',
+            label: {
+              collection: null,
+              foreignField: null,
+              fields: null
+            }
           },
         ],
       })
@@ -288,6 +303,11 @@ let AllTests = ContextureClient => {
                 lastUpdateTime: null,
                 values: ['City of Deerfield'],
                 size: 24,
+                label: {
+                  collection: null,
+                  foreignField: null,
+                  fields: null
+                }
               },
               {
                 key: 'mainQuery',

--- a/test/index.js
+++ b/test/index.js
@@ -59,8 +59,8 @@ let AllTests = ContextureClient => {
             label: {
               collection: null,
               foreignField: null,
-              fields: null
-            }
+              fields: null,
+            },
           },
           {
             key: 'results',
@@ -97,8 +97,8 @@ let AllTests = ContextureClient => {
             label: {
               collection: null,
               foreignField: null,
-              fields: null
-            }
+              fields: null,
+            },
           },
           {
             key: 'results',
@@ -133,8 +133,8 @@ let AllTests = ContextureClient => {
             label: {
               collection: null,
               foreignField: null,
-              fields: null
-            }
+              fields: null,
+            },
           },
         ],
       })
@@ -306,8 +306,8 @@ let AllTests = ContextureClient => {
                 label: {
                   collection: null,
                   foreignField: null,
-                  fields: null
-                }
+                  fields: null,
+                },
               },
               {
                 key: 'mainQuery',

--- a/test/index.js
+++ b/test/index.js
@@ -356,6 +356,11 @@ let AllTests = ContextureClient => {
               size: 24,
               filterOnly: true,
               optionsFilter: '',
+              label: {
+                collection: null,
+                foreignField: null,
+                fields: null,
+              },
             },
             {
               key: 'mainQuery',


### PR DESCRIPTION
Fixes #126 

### Description
* part of allowing the display of something other than a facet value itself as its label -- currently data for this needs to be loaded separately. https://github.com/smartprocure/contexture-mongo/pull/65 supports the props and https://github.com/smartprocure/contexture-react/pull/390 uses them