### PR TITLE
 should not  trigger an update, unless using the isForceUpdate option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.32.0
-* add the feature calling mutate on the same values should not  trigger an update, unless use the isForceUpdate option
+* add the feature calling mutate on the same values should not  trigger an update, unless using the isForceUpdate option
 * fix typo errors
 
 # 2.31.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.32.0
+* add the feature calling mutate on the same values should not  trigger an update, unless use the isForceUpdate option
+* fix typo errors
+
 # 2.31.2
 * Update subquery node reactors to `all`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.32.0
-* add the feature calling mutate on the same values should not  trigger an update, unless using the isForceUpdate option
-* fix typo errors
+* Add the feature calling mutate on the same values should not  trigger an update, unless using the isForceUpdate option
+* Fix typo errors
 
 # 2.31.2
 * Update subquery node reactors to `all`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.31.2",
+  "version": "2.32.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.31.2",
+  "version": "2.32.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,10 +63,11 @@ export default config => {
     return dispatch({ type: 'remove', path, previous })
   }
 
-  let mutate = _.curry(async (path, value,isForceUpdate=false) => {
+  let mutate = _.curry(async (path, value, isForceUpdate = false) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
-    if( _.flow(F.simpleDiff,_.isEmpty)(previous,value) && !isForceUpdate) return
+    if (_.flow(F.simpleDiff, _.isEmpty)(previous, value) && !isForceUpdate)
+      return
     extend(target, value)
     return dispatch({
       type: 'mutate',

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -66,6 +66,9 @@ export default config => {
   let mutate = _.curry(async (path, value, isForceUpdate = false) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
+    console.log(previous)
+    console.log(value)
+    console.log(_.flow(F.simpleDiff, _.isEmpty)(previous, value))
     if (_.flow(F.simpleDiff, _.isEmpty)(previous, value) && !isForceUpdate)
       return
     extend(target, value)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,12 +63,12 @@ export default config => {
 
     return dispatch({ type: 'remove', path, previous })
   }
-  let toJsIsEqual =(x,y)=>_.isEqual(toJS(x),y)
+  let toJsIsEqual = (x, y) => _.isEqual(toJS(x), y)
 
   let mutate = _.curry(async (path, value, isForceUpdate = false) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
-    if (_.isMatchWith(toJsIsEqual, value,previous) && !isForceUpdate) return
+    if (_.isMatchWith(toJsIsEqual, value, previous) && !isForceUpdate) return
     extend(target, value)
     return dispatch({
       type: 'mutate',

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -41,7 +41,7 @@ export default config => {
       { target, dedupe: parentDedupe }
     )
 
-    // consider moving this in the tree walk? it could work for al children too but would be exgra work for chilren
+    // consider moving this in the tree walk? it could work for al children too but would be extra work for children
     pushOrSpliceOn(target.children, node, index)
     // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
     // flat[encode(path)] = target.children[index]
@@ -63,10 +63,10 @@ export default config => {
     return dispatch({ type: 'remove', path, previous })
   }
 
-  let mutate = _.curry(async (path, value) => {
+  let mutate = _.curry(async (path, value,isForceUpdate=false) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
-    if(_.flow(F.simpleDiff,_.isEmpty)(previous,value)) return
+    if( _.flow(F.simpleDiff,_.isEmpty)(previous,value) && !isForceUpdate) return
     extend(target, value)
     return dispatch({
       type: 'mutate',

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -66,11 +66,7 @@ export default config => {
   let mutate = _.curry(async (path, value, isForceUpdate = false) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
-    console.log(previous)
-    console.log(value)
-    console.log(_.flow(F.simpleDiff, _.isEmpty)(previous, value))
-    if (_.flow(F.simpleDiff, _.isEmpty)(previous, value) && !isForceUpdate)
-      return
+    if (_.flow(F.simpleDiff, _.isEmpty)(previous, value) && !isForceUpdate) return
     extend(target, value)
     return dispatch({
       type: 'mutate',
@@ -89,7 +85,7 @@ export default config => {
   let clear = path =>
     mutate(
       path,
-      _.omit(['field'], getTypeProp(types, 'defaults', getNode(path)))
+      _.omit(['field'], getTypeProp(types, 'defaults', getNode(path))),true
     )
 
   let replace = (path, transform) => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,7 +4,7 @@ import { encode, Tree } from '../util/tree'
 import { getTypeProp } from '../types'
 import wrap from './wrap'
 import { dedupeWalk } from '../node'
-import { observable, reaction, toJS, set } from 'mobx'
+import { toJS } from 'mobx'
 
 let pushOrSpliceOn = (array, item, index) => {
   if (index === undefined) array.push(item)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -66,6 +66,7 @@ export default config => {
   let mutate = _.curry(async (path, value) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
+    if(_.flow(F.simpleDiff,_.isEmpty)(previous,value)) return
     extend(target, value)
     return dispatch({
       type: 'mutate',

--- a/src/actions/wrap.js
+++ b/src/actions/wrap.js
@@ -13,7 +13,7 @@ export default ({ getNode, flat }, { mutate, replace, remove, add }) => {
     // Clone the root node since we'll be modifying it in place in the tree
     let node = shallowCloneNode(getNode(path))
 
-    // Remove all children (they'll be readded at the end when we add the shallow clone)
+    // Remove all children (they'll be read at the end when we add the shallow clone)
     await Promise.all(_.map(child => remove(child.path), node.children))
 
     // Mutate existing root into new root

--- a/src/subquery.js
+++ b/src/subquery.js
@@ -15,7 +15,7 @@ let mapSubqueryValuesByType = (sourceNode, targetNode, types) =>
       )(values, targetNode)
   )(sourceNode)
 
-// A subquery (in contexture-client) is about taking the output of one search and makng it the input for another search.
+// A subquery (in contexture-client) is about taking the output of one search and making it the input for another search.
 // This is an in memory, cross-database, "select in" join on sources that don't need to be relational.
 export default _.curry(
   (
@@ -51,7 +51,7 @@ export default _.curry(
       _.flow(
         mapSubqueryValues,
         // If the sourceTree has no values at all clear the targetTree, otherwise mutate with the new values.
-        // This is needed in the cases where the intial values are removed and there are no values in the source tree anymore.
+        // This is needed in the cases where the initial values are removed and there are no values in the source tree anymore.
         _.get('tree.hasValue', sourceTree)
           ? targetTree.mutate(targetPath)
           : () => targetTree.clear(targetPath)

--- a/test/index.js
+++ b/test/index.js
@@ -1125,7 +1125,7 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([])
 
     // Mutate on sourceTree will await the Subquery into targetTree
-    expect(spy).to.have.callCount(2)
+    expect(spy).to.have.callCount(1)
   })
   it('should respect disableAutoUpdate', async () => {
     let service = sinon.spy(mockService())

--- a/test/index.js
+++ b/test/index.js
@@ -1125,7 +1125,7 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([])
 
     // Mutate on sourceTree will await the Subquery into targetTree
-    expect(spy).to.have.callCount(1)
+    expect(spy).to.have.callCount(2)
   })
   it('should respect disableAutoUpdate', async () => {
     let service = sinon.spy(mockService())
@@ -1885,7 +1885,7 @@ let AllTests = ContextureClient => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
       let tree = Tree(treeConfig)
-      await tree.mutate(['root', 'results'], { page: 2, type: 'results' })
+      await tree.mutate(['root', 'results'], { page: 2 })
       await tree.mutate(['root', 'results'], { page: 2 })
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(1)

--- a/test/index.js
+++ b/test/index.js
@@ -855,7 +855,7 @@ let AllTests = ContextureClient => {
     )
     tree.mutate(['root', 'a'], { values: [1] })
     let node = tree.getNode(['root', 'b'])
-    // Allow updating to start (after debounce elaspses) but before the service finishes
+    // Allow updating to start (after debounce elapses) but before the service finishes
     await Promise.delay(5)
     expect(node.updating).to.be.true
     await node.updatingPromise
@@ -1794,13 +1794,13 @@ let AllTests = ContextureClient => {
         },
       }[type])
     let service = mockService({ mocks })
-    let TreeJustForthisTest = ContextureClient({
+    let TreeJustForThisTest = ContextureClient({
       debounce: 1,
       service,
       debug: true,
       log() {},
     })
-    let tree = TreeJustForthisTest({
+    let tree = TreeJustForThisTest({
       key: 'root',
       join: 'and',
       children: [
@@ -1849,6 +1849,66 @@ let AllTests = ContextureClient => {
       Tree.tree.children[0].children[0].context.response.totalRecords
     ).to.equal(1337)
     expect(service).to.have.callCount(0)
+  })
+
+  it(' should trigger an update if values are different', async () => {
+    let service = sinon.spy(mockService())
+    let Tree = ContextureClient({ debounce: 1, service })
+    let tree = Tree({
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'results',
+          type: 'results',
+          page: 1,
+        },
+        {
+          key: 'agencies',
+          field: 'Organization.Name',
+          type: 'facet',
+        },
+        {
+          key: 'vendors',
+          field: 'Vendor.Name',
+          type: 'facet',
+        },
+      ],
+    })
+    await tree.mutate(['root', 'results'], { page: 3 , type: 'results'})
+    await tree.mutate(['root', 'results'], { page: 2 })
+    expect(tree.getNode(['root', 'results']).page).to.equal(2)
+    expect(service).to.have.callCount(2)
+
+  })
+  it(' should not trigger an update if values are same', async () => {
+    let service = sinon.spy(mockService())
+    let Tree = ContextureClient({ debounce: 1, service })
+    let tree = Tree({
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'results',
+          type: 'results',
+          page: 1,
+        },
+        {
+          key: 'agencies',
+          field: 'Organization.Name',
+          type: 'facet',
+        },
+        {
+          key: 'vendors',
+          field: 'Vendor.Name',
+          type: 'facet',
+        },
+      ],
+    })
+    await tree.mutate(['root', 'results'], { page: 2 , type: 'results'})
+    await tree.mutate(['root', 'results'], { page: 2 })
+    expect(tree.getNode(['root', 'results']).page).to.equal(2)
+    expect(service).to.have.callCount(1)
   })
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1850,66 +1850,128 @@ let AllTests = ContextureClient => {
     ).to.equal(1337)
     expect(service).to.have.callCount(0)
   })
+  describe('smart mutate', () => {
+    it(' should trigger an update if values are different without force update option', async () => {
+      let service = sinon.spy(mockService())
+      let Tree = ContextureClient({ debounce: 1, service })
+      let tree = Tree({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+          },
+          {
+            key: 'agencies',
+            field: 'Organization.Name',
+            type: 'facet',
+          },
+          {
+            key: 'vendors',
+            field: 'Vendor.Name',
+            type: 'facet',
+          },
+        ],
+      })
+      await tree.mutate(['root', 'results'], { page: 3 , type: 'results'})
+      await tree.mutate(['root', 'results'], { page: 2 })
+      expect(tree.getNode(['root', 'results']).page).to.equal(2)
+      expect(service).to.have.callCount(2)
 
-  it(' should trigger an update if values are different', async () => {
-    let service = sinon.spy(mockService())
-    let Tree = ContextureClient({ debounce: 1, service })
-    let tree = Tree({
-      key: 'root',
-      join: 'and',
-      children: [
-        {
-          key: 'results',
-          type: 'results',
-          page: 1,
-        },
-        {
-          key: 'agencies',
-          field: 'Organization.Name',
-          type: 'facet',
-        },
-        {
-          key: 'vendors',
-          field: 'Vendor.Name',
-          type: 'facet',
-        },
-      ],
     })
-    await tree.mutate(['root', 'results'], { page: 3 , type: 'results'})
-    await tree.mutate(['root', 'results'], { page: 2 })
-    expect(tree.getNode(['root', 'results']).page).to.equal(2)
-    expect(service).to.have.callCount(2)
+    it(' should not trigger an update if values are same without force update option', async () => {
+      let service = sinon.spy(mockService())
+      let Tree = ContextureClient({ debounce: 1, service })
+      let tree = Tree({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+          },
+          {
+            key: 'agencies',
+            field: 'Organization.Name',
+            type: 'facet',
+          },
+          {
+            key: 'vendors',
+            field: 'Vendor.Name',
+            type: 'facet',
+          },
+        ],
+      })
+      await tree.mutate(['root', 'results'], { page: 2 , type: 'results'})
+      await tree.mutate(['root', 'results'], { page: 2 })
+      expect(tree.getNode(['root', 'results']).page).to.equal(2)
+      expect(service).to.have.callCount(1)
+    })
+    it(' should trigger an update if values are different with force update option', async () => {
+      let service = sinon.spy(mockService())
+      let Tree = ContextureClient({ debounce: 1, service })
+      let tree = Tree({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+          },
+          {
+            key: 'agencies',
+            field: 'Organization.Name',
+            type: 'facet',
+          },
+          {
+            key: 'vendors',
+            field: 'Vendor.Name',
+            type: 'facet',
+          },
+        ],
+      })
+      await tree.mutate(['root', 'results'], { page: 3 , type: 'results'},true)
+      await tree.mutate(['root', 'results'], { page: 2 },true)
+      expect(tree.getNode(['root', 'results']).page).to.equal(2)
+      expect(service).to.have.callCount(2)
+
+    })
+    it.only(' should not trigger an update if values are same with force update option', async () => {
+      let service = sinon.spy(mockService())
+      let Tree = ContextureClient({ debounce: 1, service })
+      let tree = Tree({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+          },
+          {
+            key: 'agencies',
+            field: 'Organization.Name',
+            type: 'facet',
+          },
+          {
+            key: 'vendors',
+            field: 'Vendor.Name',
+            type: 'facet',
+          },
+        ],
+      })
+      await tree.mutate(['root', 'results'], { page: 2 , type: 'results'})
+      await tree.mutate(['root', 'results'], { page: 2 },true)
+      expect(tree.getNode(['root', 'results']).page).to.equal(2)
+      expect(service).to.have.callCount(2)
+    })
 
   })
-  it(' should not trigger an update if values are same', async () => {
-    let service = sinon.spy(mockService())
-    let Tree = ContextureClient({ debounce: 1, service })
-    let tree = Tree({
-      key: 'root',
-      join: 'and',
-      children: [
-        {
-          key: 'results',
-          type: 'results',
-          page: 1,
-        },
-        {
-          key: 'agencies',
-          field: 'Organization.Name',
-          type: 'facet',
-        },
-        {
-          key: 'vendors',
-          field: 'Vendor.Name',
-          type: 'facet',
-        },
-      ],
-    })
-    await tree.mutate(['root', 'results'], { page: 2 , type: 'results'})
-    await tree.mutate(['root', 'results'], { page: 2 })
-    expect(tree.getNode(['root', 'results']).page).to.equal(2)
-    expect(service).to.have.callCount(1)
-  })
+
 }
 
 describe('lib', () => AllTests(ContextureClient))

--- a/test/index.js
+++ b/test/index.js
@@ -1851,30 +1851,31 @@ let AllTests = ContextureClient => {
     expect(service).to.have.callCount(0)
   })
   describe('smart mutate', () => {
+    let treeConfig = {
+      key: 'root',
+      join: 'and',
+      children: [
+        {
+          key: 'results',
+          type: 'results',
+          page: 1,
+        },
+        {
+          key: 'agencies',
+          field: 'Organization.Name',
+          type: 'facet',
+        },
+        {
+          key: 'vendors',
+          field: 'Vendor.Name',
+          type: 'facet',
+        },
+      ],
+    }
     it(' should trigger an update if values are different without force update option', async () => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
-      let tree = Tree({
-        key: 'root',
-        join: 'and',
-        children: [
-          {
-            key: 'results',
-            type: 'results',
-            page: 1,
-          },
-          {
-            key: 'agencies',
-            field: 'Organization.Name',
-            type: 'facet',
-          },
-          {
-            key: 'vendors',
-            field: 'Vendor.Name',
-            type: 'facet',
-          },
-        ],
-      })
+      let tree = Tree(treeConfig)
       await tree.mutate(['root', 'results'], { page: 3, type: 'results' })
       await tree.mutate(['root', 'results'], { page: 2 })
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
@@ -1883,27 +1884,7 @@ let AllTests = ContextureClient => {
     it(' should not trigger an update if values are same without force update option', async () => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
-      let tree = Tree({
-        key: 'root',
-        join: 'and',
-        children: [
-          {
-            key: 'results',
-            type: 'results',
-            page: 1,
-          },
-          {
-            key: 'agencies',
-            field: 'Organization.Name',
-            type: 'facet',
-          },
-          {
-            key: 'vendors',
-            field: 'Vendor.Name',
-            type: 'facet',
-          },
-        ],
-      })
+      let tree = Tree(treeConfig)
       await tree.mutate(['root', 'results'], { page: 2, type: 'results' })
       await tree.mutate(['root', 'results'], { page: 2 })
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
@@ -1912,56 +1893,16 @@ let AllTests = ContextureClient => {
     it(' should trigger an update if values are different with force update option', async () => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
-      let tree = Tree({
-        key: 'root',
-        join: 'and',
-        children: [
-          {
-            key: 'results',
-            type: 'results',
-            page: 1,
-          },
-          {
-            key: 'agencies',
-            field: 'Organization.Name',
-            type: 'facet',
-          },
-          {
-            key: 'vendors',
-            field: 'Vendor.Name',
-            type: 'facet',
-          },
-        ],
-      })
+      let tree = Tree(treeConfig)
       await tree.mutate(['root', 'results'], { page: 3, type: 'results' }, true)
       await tree.mutate(['root', 'results'], { page: 2 }, true)
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(2)
     })
-    it.only(' should not trigger an update if values are same with force update option', async () => {
+    it(' should not trigger an update if values are same with force update option', async () => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
-      let tree = Tree({
-        key: 'root',
-        join: 'and',
-        children: [
-          {
-            key: 'results',
-            type: 'results',
-            page: 1,
-          },
-          {
-            key: 'agencies',
-            field: 'Organization.Name',
-            type: 'facet',
-          },
-          {
-            key: 'vendors',
-            field: 'Vendor.Name',
-            type: 'facet',
-          },
-        ],
-      })
+      let tree = Tree(treeConfig)
       await tree.mutate(['root', 'results'], { page: 2, type: 'results' })
       await tree.mutate(['root', 'results'], { page: 2 }, true)
       expect(tree.getNode(['root', 'results']).page).to.equal(2)

--- a/test/index.js
+++ b/test/index.js
@@ -1125,7 +1125,7 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([])
 
     // Mutate on sourceTree will await the Subquery into targetTree
-    expect(spy).to.have.callCount(2)
+    expect(spy).to.have.callCount(1)
   })
   it('should respect disableAutoUpdate', async () => {
     let service = sinon.spy(mockService())
@@ -1885,9 +1885,10 @@ let AllTests = ContextureClient => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
       let tree = Tree(treeConfig)
-      await tree.mutate(['root', 'results'], { page: 2 })
-      await tree.mutate(['root', 'results'], { page: 2 })
-      expect(tree.getNode(['root', 'results']).page).to.equal(2)
+      await tree.mutate(['root', 'results'], { page: 4 })
+      expect(service).to.have.callCount(1)
+      await tree.mutate(['root', 'results'], { page: 4 })
+      expect(tree.getNode(['root', 'results']).page).to.equal(4)
       expect(service).to.have.callCount(1)
     })
     it(' should trigger an update if values are different with force update option', async () => {
@@ -1899,13 +1900,14 @@ let AllTests = ContextureClient => {
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(2)
     })
-    it(' should not trigger an update if values are same with force update option', async () => {
+    it(' should trigger an update if values are same with force update option', async () => {
       let service = sinon.spy(mockService())
       let Tree = ContextureClient({ debounce: 1, service })
       let tree = Tree(treeConfig)
-      await tree.mutate(['root', 'results'], { page: 2, type: 'results' })
-      await tree.mutate(['root', 'results'], { page: 2 }, true)
-      expect(tree.getNode(['root', 'results']).page).to.equal(2)
+      await tree.mutate(['root', 'results'], { page: 3, type: 'results' })
+      expect(service).to.have.callCount(1)
+      await tree.mutate(['root', 'results'], { page: 3 }, true)
+      expect(tree.getNode(['root', 'results']).page).to.equal(3)
       expect(service).to.have.callCount(2)
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -1875,11 +1875,10 @@ let AllTests = ContextureClient => {
           },
         ],
       })
-      await tree.mutate(['root', 'results'], { page: 3 , type: 'results'})
+      await tree.mutate(['root', 'results'], { page: 3, type: 'results' })
       await tree.mutate(['root', 'results'], { page: 2 })
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(2)
-
     })
     it(' should not trigger an update if values are same without force update option', async () => {
       let service = sinon.spy(mockService())
@@ -1905,7 +1904,7 @@ let AllTests = ContextureClient => {
           },
         ],
       })
-      await tree.mutate(['root', 'results'], { page: 2 , type: 'results'})
+      await tree.mutate(['root', 'results'], { page: 2, type: 'results' })
       await tree.mutate(['root', 'results'], { page: 2 })
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(1)
@@ -1934,11 +1933,10 @@ let AllTests = ContextureClient => {
           },
         ],
       })
-      await tree.mutate(['root', 'results'], { page: 3 , type: 'results'},true)
-      await tree.mutate(['root', 'results'], { page: 2 },true)
+      await tree.mutate(['root', 'results'], { page: 3, type: 'results' }, true)
+      await tree.mutate(['root', 'results'], { page: 2 }, true)
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(2)
-
     })
     it.only(' should not trigger an update if values are same with force update option', async () => {
       let service = sinon.spy(mockService())
@@ -1964,14 +1962,12 @@ let AllTests = ContextureClient => {
           },
         ],
       })
-      await tree.mutate(['root', 'results'], { page: 2 , type: 'results'})
-      await tree.mutate(['root', 'results'], { page: 2 },true)
+      await tree.mutate(['root', 'results'], { page: 2, type: 'results' })
+      await tree.mutate(['root', 'results'], { page: 2 }, true)
       expect(tree.getNode(['root', 'results']).page).to.equal(2)
       expect(service).to.have.callCount(2)
     })
-
   })
-
 }
 
 describe('lib', () => AllTests(ContextureClient))


### PR DESCRIPTION
Fix #97 
1. Add the feature calling mutate on the same values should not trigger an update, unless using the `isForceUpdate` option.
2. Fix typo errors.