### PR TITLE
Feature/142 - update tagsQuery context reactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.32.0
+* Update `tagsQuery` reactors to `all` to support showing counts on tags
+
 # 2.31.2
 * Update subquery node reactors to `all`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.31.2",
+  "version": "2.32.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.31.2",
+  "version": "2.32.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -101,8 +101,8 @@ export default F.stampKey('type', {
     validate: _.get('tags.length'),
     reactors: {
       join: 'others',
-      tags: 'others',
-      exact: 'others',
+      tags: 'all',
+      exact: 'all',
     },
     defaults: {
       field: null,


### PR DESCRIPTION
Fixes #142 

### Description
* We need to get fresh results if `tags` or `exact` are changed now that the results will be counts by individual tag (https://github.com/smartprocure/contexture-elasticsearch/pull/163). `join` itself doesn't require a fresh calculation of results because it doesn't matter for the count on a single tag so that can stay `others`