### PR TITLE
Default date type range to `exact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.32.2
+* set default date.range to 'exact'
 # 2.32.1
 * set default context.results to [] for `tagsQuery`
 # 2.32.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -194,7 +194,7 @@ export default F.stampKey('type', {
       field: null,
       from: null,
       to: null,
-      range: null,
+      range: 'exact',
       timezone: null,
     },
   },


### PR DESCRIPTION
- Default the range the actual default value of `exact`. 