### PR TITLE
Debounce immediate updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.35.0
-* Immediate u[dates are now debounced 10ms (which happens on self affecting reactors when disableAutoUpdate is true)
+* Immediate updates are now debounced 10ms (which happens on self affecting reactors when disableAutoUpdate is true)
 
 # 2.34.0
 * Silencing updates from changes with no value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.35.0
+* Immediate u[dates are now debounced 10ms (which happens on self affecting reactors when disableAutoUpdate is true)
+
 # 2.34.0
 * Silencing updates from changes with no value
 * This removes unnecessary tree update when switching from exact to rolling 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -147,9 +147,11 @@ export let ContextTree = _.curry(
       }
     }
     let triggerDelayedUpdate = F.debounceAsync(debounce, triggerImmediateUpdate)
+    // Even in immediate update mode, debounce by a very small amount to avoid spamming
+    let triggerSafeImmediateUpdate = F.debounceAsync(10, triggerImmediateUpdate)
     let triggerUpdate = path =>
       TreeInstance.disableAutoUpdate
-        ? triggerImmediateUpdate(path)
+        ? triggerSafeImmediateUpdate(path)
         : triggerDelayedUpdate(path)
 
     let processResponse = async data => {
@@ -199,7 +201,7 @@ export let ContextTree = _.curry(
     }
 
     let TreeInstance = initObject({
-      serialize: () => serialize(snapshot(tree), {}),
+      serialize: path => serialize(snapshot(path ? getNode(path) : tree), {}),
       tree,
       debugInfo,
       ...actionProps,

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -9,9 +9,7 @@ let getNilKeys = _.flow(_.pickBy(_.isNil), _.keys)
 export default (tree, { search } = {}) =>
   _.tap(
     Tree.walk(x => {
-      if (search && isFilterOnly(x)) {
-        x.filterOnly = true
-      }
+      if (search && isFilterOnly(x)) x.filterOnly = true
       _.each(unsetOn(_, x), [
         ..._.keys(_.omit(search ? 'lastUpdateTime' : '', internalStateKeys)),
         ...getNilKeys(x),

--- a/test/index.js
+++ b/test/index.js
@@ -1261,6 +1261,46 @@ let AllTests = ContextureClient => {
       key: 'root',
     })
   })
+
+  it('should still debounce disableAutoUpdate even with self affecting reactors that triggerImmediate', async () => {
+    let service = sinon.spy(mockService())
+    let Tree = ContextureClient({
+      service,
+      debounce: 1,
+      disableAutoUpdate: true,
+    })
+    let tree = Tree({
+      key: 'root',
+      join: 'and',
+      children: [
+        { key: 'filter1', type: 'tagsQuery', field: 'facetfield' },
+        { key: 'results', type: 'results' }
+      ],
+    })
+    expect(service).to.have.callCount(0)
+
+    // Tags mutate has a self affecting reactor (`all`), which will triggerImmediate and bypass disableAutoUpdate
+    let toTags = _.map(word => ({ word }))
+    let calls = [
+      tree.mutate(['root', 'filter1'], { tags: toTags(['1']) }),
+      tree.mutate(['root', 'filter1'], { tags: toTags(['1', '2']) }),
+      tree.mutate(['root', 'filter1'], { tags: toTags(['1', '2', '3']) }),
+      tree.mutate(['root', 'filter1'], { tags: toTags(['1', '2', '3', '4']) }),
+    ]
+    expect(service).to.have.callCount(0)
+
+    // Until immediate debounce clears, no search runs
+    await Promise.delay(5)
+    expect(service).to.have.callCount(0)
+
+    // Search should run after immediate debouce clears
+    await Promise.delay(10)
+    expect(service).to.have.callCount(1)
+
+    // Even though 4 mutate calls were made, only 1 search should have actually triggered even though it's disableAutoUpdate with a self affecting reactor because it's deboucned
+    await Promise.all(calls)
+    expect(service).to.have.callCount(1)
+  })
   it('should call onUpdateByOthers', async () => {
     let service = sinon.spy(mockService())
     let types = {

--- a/test/index.js
+++ b/test/index.js
@@ -1274,7 +1274,7 @@ let AllTests = ContextureClient => {
       join: 'and',
       children: [
         { key: 'filter1', type: 'tagsQuery', field: 'facetfield' },
-        { key: 'results', type: 'results' }
+        { key: 'results', type: 'results' },
       ],
     })
     expect(service).to.have.callCount(0)


### PR DESCRIPTION
Immediate updates are now debounced 10ms (which happens on self affecting reactors when disableAutoUpdate is true).

This should fix the issue where the tagsQuery component dispatches tons of mutates when pasting a large number of tags (which all triggerImmediate because they have self affecting reactors)