### PR TITLE
Fixes: filterOnly for serialized tree, awaiting logic for subquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.36.0
+* Debounce for immediate updates is removed
+* Fixing logic filterOnly flag for serialized tree
+* Subquery: making whole targetTree to await for sourceNode
+
 # 2.35.0
 * Immediate updates are now debounced 10ms (which happens on self affecting reactors when disableAutoUpdate is true)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.36.0
-* Debounce for immediate updates is removed
+* Debounce for immediate updates is set to 1 ms
 * Fixing logic filterOnly flag for serialized tree
 * Subquery: making whole targetTree to await for sourceNode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export let ContextTree = _.curry(
     }
 
     // If specifying path, *only* update that path
-    let triggerImmediateUpdate = async path => {
+    let runUpdate = async path => {
       if (shouldBlockUpdate(flat)) return log('Blocked Search')
       let now = new Date().getTime()
       let node = getNode(path)
@@ -146,7 +146,8 @@ export let ContextTree = _.curry(
         onError(error) // Raise the onError event
       }
     }
-    let triggerDelayedUpdate = F.debounceAsync(debounce, triggerImmediateUpdate)
+    let triggerImmediateUpdate = F.debounceAsync(1, runUpdate)
+    let triggerDelayedUpdate = F.debounceAsync(debounce, runUpdate)
     let triggerUpdate = path =>
       TreeInstance.disableAutoUpdate
         ? triggerImmediateUpdate(path)

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,11 @@ export let ContextTree = _.curry(
           TreeInstance.onResult(path, node, target)
           mergeWith((oldValue, newValue) => newValue, target, responseNode)
           if (debug && node._meta) target.metaHistory.push(node._meta)
+        }
 
+        extend(target, { updating: false })
+
+        if (!_.isEmpty(responseNode)) {
           try {
             target.updatingDeferred.resolve()
           } catch (e) {
@@ -179,10 +183,8 @@ export let ContextTree = _.curry(
               'Tried to resolve a node that had no updatingDeferred. This usually means there was unsolicited results from the server for a node that has never been updated.'
             )
           }
-
           await F.maybeCall(target.afterSearch)
         }
-        extend(target, { updating: false })
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,7 @@ export let ContextTree = _.curry(
       if (path) {
         Tree.walk((node, index, parents) => {
           let nodePath = [..._.map('key', _.reverse(parents)), node.key]
+          // marking everything that isn’t the node or it’s children
           if (!_.isEqual(path, nodePath) && !isParent(path, nodePath)) {
             node.filterOnly = true
           }

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ export let ContextTree = _.curry(
       if (path) {
         Tree.walk((node, index, parents) => {
           let nodePath = [..._.map('key', _.reverse(parents)), node.key]
-          if (!_.isEqual(path, nodePath) && !isParent(path, nodePath)){
+          if (!_.isEqual(path, nodePath) && !isParent(path, nodePath)) {
             node.filterOnly = true
           }
         })(body)

--- a/src/subquery.js
+++ b/src/subquery.js
@@ -1,5 +1,4 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
 import { getTypePropOrError } from './types'
 
 // This is factored out to make it easy to eventually support custom mapSubqueryValues functions
@@ -46,12 +45,12 @@ export default _.curry(
     // targetNode.onMarkForUpdate = () => sourceNode.updatingPromise
 
     // This version would not mark targetNode for update until sourceNode is done:
-    // Using debounceAsync because updatingPromise is initialized after validation stage
-    // and we can resolve several validate calls with the latest updatingPromise
-    targetNode.validate = F.debounceAsync(0, async () => {
+    // Using setTimeout because updatingPromise is initialized after validation stage
+    targetNode.validate = async () => {
+      await new Promise(resolve => setTimeout(resolve))
       await sourceNode.updatingPromise
       return true
-    })
+    }
 
     // Could also use onResult, but this is more direct and avoids having to cache
     // the promise for this mutate action somewhere

--- a/src/subquery.js
+++ b/src/subquery.js
@@ -1,6 +1,8 @@
 import _ from 'lodash/fp'
 import { getTypePropOrError } from './types'
 
+let delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 // This is factored out to make it easy to eventually support custom mapSubqueryValues functions
 let mapSubqueryValuesByType = (sourceNode, targetNode, types) =>
   _.flow(
@@ -47,7 +49,7 @@ export default _.curry(
     // This version would not mark targetNode for update until sourceNode is done:
     // Using setTimeout because updatingPromise is initialized after validation stage
     targetNode.validate = async () => {
-      await new Promise(resolve => setTimeout(resolve))
+      await delay()
       await sourceNode.updatingPromise
       return true
     }

--- a/test/index.js
+++ b/test/index.js
@@ -991,13 +991,10 @@ let AllTests = ContextureClient => {
   it('should support subquery', async () => {
     let spy = sinon.spy(
       mockService({
-        mocks({ key, type }) {
+        mocks({ type }) {
           if (type === 'facet')
             return {
-              options: {
-                c: [{ name: 1 }, { name: 2 }],
-                a: [{ name: 3 }, { name: 4 }],
-              }[key],
+              options: [{ name: 1 }, { name: 2 }],
             }
           if (type === 'results')
             return {
@@ -1043,6 +1040,7 @@ let AllTests = ContextureClient => {
 
     // subquery(types, targetTree, ['root', 'a'], sourceTree, ['innerRoot', 'c'])
     targetTree.subquery(['root', 'a'], sourceTree, ['innerRoot', 'c'])
+    targetTree.dispatch({ type: 'all', path: ['root', 'b'] })
     let promise = sourceTree.mutate(['innerRoot', 'd'], { values: ['test'] })
 
     await promise
@@ -1052,6 +1050,7 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([1, 2])
 
     // Mutate on sourceTree will await the Subquery into targetTree
+    // so results are fetched only once despite dispatching them directly
     expect(spy).to.have.callCount(2)
 
     expect(targetTree.getNode(['root', 'b']).markedForUpdate).to.be.false
@@ -1105,10 +1104,14 @@ let AllTests = ContextureClient => {
     let targetTree = Tree({
       key: 'root',
       join: 'and',
-      children: [{ key: 'a', type: 'facet', values: [] }],
+      children: [
+        { key: 'a', type: 'facet', values: [] },
+        { key: 'b', type: 'results' },
+      ],
     })
 
     targetTree.subquery(['root', 'a'], sourceTree, ['innerRoot', 'c'])
+    targetTree.dispatch({ type: 'all', path: ['root', 'b'] })
     let promise = sourceTree.mutate(['innerRoot', 'd'], { values: ['test'] })
 
     await promise
@@ -1118,6 +1121,7 @@ let AllTests = ContextureClient => {
     expect(targetTree.getNode(['root', 'a']).values).to.deep.equal([])
 
     // Mutate on sourceTree will await the Subquery into targetTree
+    // so results are fetched only once despite dispatching them directly
     expect(spy).to.have.callCount(2)
   })
   it('should respect disableAutoUpdate', async () => {
@@ -1211,13 +1215,15 @@ let AllTests = ContextureClient => {
       join: 'and',
       children: [
         { key: 'results', type: 'results' },
-        { key: 'agencies', field: 'Organization.Name', type: 'facet' },
-        { key: 'vendors', field: 'Vendor.Name', type: 'facet' },
+        { key: 'criteria', children: [
+          { key: 'agencies', field: 'Organization.Name', type: 'facet' },
+          { key: 'vendors', field: 'Vendor.Name', type: 'facet', forceFilterOnly: true },
+        ]},
       ],
     })
 
-    // Trigger Update should also let searches through
-    await tree.mutate(['root', 'agencies'], { size: 12 })
+    // Trigger Update should let only targeted search through
+    await tree.mutate(['root', 'criteria', 'agencies'], { size: 12 })
     expect(service).to.have.callCount(1)
     let [dto, now] = service.getCall(0).args
     expect(dto).to.deep.equal({
@@ -1230,28 +1236,81 @@ let AllTests = ContextureClient => {
           type: 'results',
         },
         {
-          field: 'Organization.Name',
-          key: 'agencies',
-          lastUpdateTime: now,
-          mode: 'include',
-          optionsFilter: '',
-          size: 12,
-          type: 'facet',
-          values: [],
-        },
-        {
-          field: 'Vendor.Name',
           filterOnly: true,
-          key: 'vendors',
-          mode: 'include',
-          optionsFilter: '',
-          type: 'facet',
-          values: [],
+          key: 'criteria',
+          children: [
+            {
+              field: 'Organization.Name',
+              key: 'agencies',
+              lastUpdateTime: now,
+              mode: 'include',
+              optionsFilter: '',
+              size: 12,
+              type: 'facet',
+              values: [],
+            },
+            {
+              field: 'Vendor.Name',
+              forceFilterOnly: true,
+              filterOnly: true,
+              key: 'vendors',
+              mode: 'include',
+              optionsFilter: '',
+              type: 'facet',
+              values: [],
+            },
+          ],
         },
       ],
       filterOnly: true,
       join: 'and',
       key: 'root',
+    })
+    // Refreshing whole tree shouldn't block searches
+    await tree.dispatch({ type: 'refresh' , path: ['root'] })
+    expect(service).to.have.callCount(2)
+    let [body, ts] = service.getCall(1).args
+
+    expect(body).to.deep.equal({
+      children: [
+        {
+          key: 'results',
+          page: 1,
+          pageSize: 10,
+          type: 'results',
+          lastUpdateTime: ts,
+        },
+        {
+          key: 'criteria',
+          lastUpdateTime: ts,
+          children: [
+            {
+              field: 'Organization.Name',
+              key: 'agencies',
+              mode: 'include',
+              optionsFilter: '',
+              size: 12,
+              type: 'facet',
+              values: [],
+              lastUpdateTime: ts,
+            },
+            {
+              field: 'Vendor.Name',
+              forceFilterOnly: true,
+              filterOnly: true,
+              key: 'vendors',
+              mode: 'include',
+              optionsFilter: '',
+              type: 'facet',
+              values: [],
+              lastUpdateTime: ts,
+            },
+          ],
+        },
+      ],
+      join: 'and',
+      key: 'root',
+      lastUpdateTime: ts,
     })
   })
   it('should call onUpdateByOthers', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -1045,10 +1045,6 @@ let AllTests = ContextureClient => {
     targetTree.subquery(['root', 'a'], sourceTree, ['innerRoot', 'c'])
     let promise = sourceTree.mutate(['innerRoot', 'd'], { values: ['test'] })
 
-    // Expect the toNode to be marked for update immediately
-    await Promise.delay(1)
-    expect(targetTree.getNode(['root', 'a']).markedForUpdate).to.be.true
-
     await promise
     expect(
       sourceTree.getNode(['innerRoot', 'c']).context.options
@@ -1114,8 +1110,6 @@ let AllTests = ContextureClient => {
 
     targetTree.subquery(['root', 'a'], sourceTree, ['innerRoot', 'c'])
     let promise = sourceTree.mutate(['innerRoot', 'd'], { values: ['test'] })
-    await Promise.delay(1)
-    expect(targetTree.getNode(['root', 'a']).markedForUpdate).to.be.true
 
     await promise
     expect(
@@ -1237,7 +1231,6 @@ let AllTests = ContextureClient => {
         },
         {
           field: 'Organization.Name',
-          filterOnly: false,
           key: 'agencies',
           lastUpdateTime: now,
           mode: 'include',
@@ -1260,46 +1253,6 @@ let AllTests = ContextureClient => {
       join: 'and',
       key: 'root',
     })
-  })
-
-  it('should still debounce disableAutoUpdate even with self affecting reactors that triggerImmediate', async () => {
-    let service = sinon.spy(mockService())
-    let Tree = ContextureClient({
-      service,
-      debounce: 1,
-      disableAutoUpdate: true,
-    })
-    let tree = Tree({
-      key: 'root',
-      join: 'and',
-      children: [
-        { key: 'filter1', type: 'tagsQuery', field: 'facetfield' },
-        { key: 'results', type: 'results' },
-      ],
-    })
-    expect(service).to.have.callCount(0)
-
-    // Tags mutate has a self affecting reactor (`all`), which will triggerImmediate and bypass disableAutoUpdate
-    let toTags = _.map(word => ({ word }))
-    let calls = [
-      tree.mutate(['root', 'filter1'], { tags: toTags(['1']) }),
-      tree.mutate(['root', 'filter1'], { tags: toTags(['1', '2']) }),
-      tree.mutate(['root', 'filter1'], { tags: toTags(['1', '2', '3']) }),
-      tree.mutate(['root', 'filter1'], { tags: toTags(['1', '2', '3', '4']) }),
-    ]
-    expect(service).to.have.callCount(0)
-
-    // Until immediate debounce clears, no search runs
-    await Promise.delay(5)
-    expect(service).to.have.callCount(0)
-
-    // Search should run after immediate debouce clears
-    await Promise.delay(10)
-    expect(service).to.have.callCount(1)
-
-    // Even though 4 mutate calls were made, only 1 search should have actually triggered even though it's disableAutoUpdate with a self affecting reactor because it's deboucned
-    await Promise.all(calls)
-    expect(service).to.have.callCount(1)
   })
   it('should call onUpdateByOthers', async () => {
     let service = sinon.spy(mockService())

--- a/test/index.js
+++ b/test/index.js
@@ -1215,10 +1215,18 @@ let AllTests = ContextureClient => {
       join: 'and',
       children: [
         { key: 'results', type: 'results' },
-        { key: 'criteria', children: [
-          { key: 'agencies', field: 'Organization.Name', type: 'facet' },
-          { key: 'vendors', field: 'Vendor.Name', type: 'facet', forceFilterOnly: true },
-        ]},
+        {
+          key: 'criteria',
+          children: [
+            { key: 'agencies', field: 'Organization.Name', type: 'facet' },
+            {
+              key: 'vendors',
+              field: 'Vendor.Name',
+              type: 'facet',
+              forceFilterOnly: true,
+            },
+          ],
+        },
       ],
     })
 
@@ -1267,7 +1275,7 @@ let AllTests = ContextureClient => {
       key: 'root',
     })
     // Refreshing whole tree shouldn't block searches
-    await tree.dispatch({ type: 'refresh' , path: ['root'] })
+    await tree.dispatch({ type: 'refresh', path: ['root'] })
     expect(service).to.have.callCount(2)
     let [body, ts] = service.getCall(1).args
 


### PR DESCRIPTION
* Debounce for immediate updates is removed
* Fixing logic `filterOnly` flag for serialized tree
* Subquery: making the whole target tree to await for source node
