### PR TITLE
ResponseMerges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2.38.0
+* Per type response merges via `shouldMergeResponse` and `mergeResponse`- allows types to retain the response state between search calls to cleanly support things like inifinite scrolling and drilldowns. Will automatically always force response replacement when updated by others (since the query has likely changed, invalidating prior responses). This is tracked by a new `forceReplaceResponse` internal state flag per node.
 * Fix: Always `_.deepClone` defaults on node init to prevent accidentally mutating type defaults
 * Cleanup: remove references to results.context.response (since we no longer wrap results in response)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.38.0
 * Per type response merges via `shouldMergeResponse` and `mergeResponse`- allows types to retain the response state between search calls to cleanly support things like inifinite scrolling and drilldowns. Will automatically always force response replacement when updated by others (since the query has likely changed, invalidating prior responses). This is tracked by a new `forceReplaceResponse` internal state flag per node.
 * Fix: Always `_.deepClone` defaults on node init to prevent accidentally mutating type defaults
+* Cleanup: swap custom mutable mergeWith with extend
 * Cleanup: remove references to results.context.response (since we no longer wrap results in response)
 
 # 2.37.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.38.0
 * Per type response merges via `shouldMergeResponse` and `mergeResponse`- allows types to retain the response state between search calls to cleanly support things like inifinite scrolling and drilldowns. Will automatically always force response replacement when updated by others (since the query has likely changed, invalidating prior responses). This is tracked by a new `forceReplaceResponse` internal state flag per node.
+* Leverages response merge feature to implement `infiniteScroll` for `results` (just set `infiniteScroll` to true and `mutate` increments to `page`!)
 * Fix: Always `_.deepClone` defaults on node init to prevent accidentally mutating type defaults
 * Cleanup: swap custom mutable mergeWith with extend
 * Cleanup: remove references to results.context.response (since we no longer wrap results in response)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.38.0
+* Fix: Always `_.deepClone` defaults on node init to prevent accidentally mutating type defaults
 * Cleanup: remove references to results.context.response (since we no longer wrap results in response)
+
 # 2.37.0
 * Add `pivot` type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.38.0
+* Cleanup: remove references to results.context.response (since we no longer wrap results in response)
 # 2.37.0
 * Add `pivot` type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -280,33 +280,10 @@ export default F.stampKey('type', {
       values: [],
       flatten: false,
       subtotals: false,
-      drilldown: [],
       context: {
         results: [],
       },
     },
-    shouldMergeResponse: node => !_.isEmpty(node.drilldown),
-    mergeResponse: (node, response) => {
-      // node.drilldown = [
-      //   {index: 0, value: 'City A', }
-      //   {index: 0, value: {from: 0, to: 500} }
-      // ]
-      
-      // alternatively:
-      //   node.drilldown = [
-      //     'City A',
-      //     {from: 0, to: 500}
-      //   ]
-      // and then:
-      //   _.find where `key` is value on each drilldown level e.g. via Tree lookup
-
-      // node.results[drilldown[0].index]
-      let groups = _.reduce((res, drill) => {
-         return (res.groups || res)[drill.index]
-      }, node.results, node.drilldown)
-      // concat on??
-      groups.concat(response.context.results)
-    }
   },
   esTwoLevelAggregation: {
     validate: context =>

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -137,10 +137,8 @@ export default F.stampKey('type', {
       page: 1,
       pageSize: 10,
       context: {
-        response: {
-          results: [],
-          totalRecords: null,
-        },
+        results: [],
+        totalRecords: null,
       },
     },
     onUpdateByOthers(node, extend) {

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,6 @@ import lens from './lens'
 import mockService from './mockService'
 import subquery from './subquery'
 
-let mergeWith = _.mergeWith.convert({ immutable: false })
-
 let shouldBlockUpdate = flat => {
   let leaves = Tree.flatLeaves(flat)
   let noUpdates = !_.some('markedForUpdate', leaves)
@@ -193,7 +191,7 @@ export let ContextTree = _.curry(
             typeProp('mergeResponse', target)(target, responseNode, extend)
           else {
             target.forceReplaceResponse = false
-            mergeWith((oldValue, newValue) => newValue, target, responseNode)
+            extend(target, responseNode)
           }
           if (debug && node._meta) target.metaHistory.push(node._meta)
         }

--- a/src/node.js
+++ b/src/node.js
@@ -23,6 +23,7 @@ export let internalStateKeys = {
   validate: null,
   onMarkForUpdate: null,
   afterSearch: null,
+  forceReplaceResponse: false,
 }
 
 export let autoKey = x => F.compactJoin('-', [x.field, x.type]) || 'node'

--- a/src/node.js
+++ b/src/node.js
@@ -35,7 +35,7 @@ export let initNode = _.curry((extend, types, dedupe, parentPath, node) => {
   )
   extend(node, {
     ..._.omit(_.keys(node), defaults),
-    ..._.omit(_.keys(node), getTypeProp(types, 'defaults', node)),
+    ..._.omit(_.keys(node), _.cloneDeep(getTypeProp(types, 'defaults', node))),
     key,
     path: [...parentPath, key],
   })

--- a/test/index.js
+++ b/test/index.js
@@ -2019,12 +2019,40 @@ let AllTests = ContextureClient => {
       }
     )
     Tree.processResponseNode(['root', 'analysis', 'results'], {
-      context: { totalRecords: 1337 },
+      context: { response: { totalRecords: 1337 } },
     })
     expect(
-      Tree.tree.children[0].children[0].context.totalRecords
+      Tree.tree.children[0].children[0].context.response.totalRecords
     ).to.equal(1337)
     expect(service).to.have.callCount(0)
+  })
+  it('should support response merges', async () => {
+    let service = sinon.spy(mockService())
+    let Tree = ContextureClient(
+      { service, debounce: 1 },
+      {
+        key: 'root',
+        join: 'and',
+        children: [
+          { key: 'results', type: 'results', infiniteScroll: true },
+          { key: 'test', type: 'facet', values: [] },
+        ],
+      }
+    )
+
+    // Simulating infinite scroll, page 1 and 2 are combined
+    await Tree.mutate(['root', 'results'], { page: 1 }) // returns 1 record
+    await Tree.mutate(['root', 'results'], { page: 2 }) // returns 1 record
+    expect(toJS(Tree.tree.children[0].context.results)).to.deep.equal([
+      { title: 'some result' },
+      { title: 'some result' },
+    ])
+
+    // update by others forces response replace instead of merge
+    await Tree.mutate(['root', 'test'], { values: ['asdf'] })
+    expect(toJS(Tree.tree.children[0].context.results)).to.deep.equal([
+      { title: 'some result' },
+    ])
   })
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1024,18 +1024,12 @@ let AllTests = ContextureClient => {
     let sourceTree = Tree({
       key: 'innerRoot',
       join: 'and',
-      children: [
-        { key: 'c', type: 'facet' },
-        { key: 'd', type: 'facet' },
-      ],
+      children: [{ key: 'c', type: 'facet' }, { key: 'd', type: 'facet' }],
     })
     let targetTree = Tree({
       key: 'root',
       join: 'and',
-      children: [
-        { key: 'a', type: 'facet' },
-        { key: 'b', type: 'results' },
-      ],
+      children: [{ key: 'a', type: 'facet' }, { key: 'b', type: 'results' }],
     })
 
     // subquery(types, targetTree, ['root', 'a'], sourceTree, ['innerRoot', 'c'])
@@ -1096,10 +1090,7 @@ let AllTests = ContextureClient => {
     let sourceTree = Tree({
       key: 'innerRoot',
       join: 'and',
-      children: [
-        { key: 'c', type: 'facet' },
-        { key: 'd', type: 'facet' },
-      ],
+      children: [{ key: 'c', type: 'facet' }, { key: 'd', type: 'facet' }],
     })
     let targetTree = Tree({
       key: 'root',

--- a/test/index.js
+++ b/test/index.js
@@ -2028,10 +2028,10 @@ let AllTests = ContextureClient => {
       }
     )
     Tree.processResponseNode(['root', 'analysis', 'results'], {
-      context: { response: { totalRecords: 1337 } },
+      context: { totalRecords: 1337 },
     })
     expect(
-      Tree.tree.children[0].children[0].context.response.totalRecords
+      Tree.tree.children[0].children[0].context.totalRecords
     ).to.equal(1337)
     expect(service).to.have.callCount(0)
   })


### PR DESCRIPTION
* Per type response merges via `shouldMergeResponse` and `mergeResponse`- allows types to retain the response state between search calls to cleanly support things like inifinite scrolling and drilldowns. Will automatically always force response replacement when updated by others (since the query has likely changed, invalidating prior responses). This is tracked by a new `forceReplaceResponse` internal state flag per node.
* Leverages response merge feature to implement `infiniteScroll` for `results` (just set `infiniteScroll` to true and `mutate` increments to `page`!)
* Fix: Always `_.deepClone` defaults on node init to prevent accidentally mutating type defaults
* Cleanup: swap custom mutable mergeWith with extend
* Cleanup: remove references to results.context.response (since we no longer wrap results in response)