### PR TITLE
Watch Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.40.0
+* Add `watchNode`
+
 # 2.39.0
 * Add support for type specifc `onDispatch`, called when an event is dispatched with a target node with the corresponding type
 * Add `pivot` `onDispatch` which sets `forceReplaceResponse` when certain keys are mutated.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following methods are exposed on an instantiated client:
 | subquery | `(targetPath, sourceTree, sourcePath, mapSubqueryValues?) => {}` | Sets up a subquery, using the types passed in to the client and assuming this tree instance is the target tree. For more info, see the [subquery](#Subquery) section below. |
 | isPausedNested | `path -> bool` | Returns a bool for whether the node at the path and all of its children are paused. |
 | processResponseNode | `(path, node) => {}` | Used to process intermediate partial results from the server |
+| watchNode | `(path, watcherFn, [keys]) => {}` | Runs `watcherFn` any time the node at `path` is updated, optionally restricted to the array of keys passed in. `watcherFn` is called with `(node, delta)` which is a reference to the target node and the payload to update it with. Useful for implementing observability, e.g. a react hook. |
 
 #### Actions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -151,7 +151,7 @@ export default F.stampKey('type', {
         context: {
           ...response.context,
           results: [...node.context.results, ...response.context.results],
-        }
+        },
       })
     },
   },

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -147,9 +147,11 @@ export default F.stampKey('type', {
     shouldMergeResponse: node => node.infiniteScroll,
     mergeResponse(node, response, extend) {
       // extend but merge results arrays
-      extend(node.context, {
-        ...response.context,
-        results: [...node.context.results, ...response.context.results],
+      extend(node, {
+        context: {
+          ...response.context,
+          results: [...node.context.results, ...response.context.results],
+        }
       })
     },
   },

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import exampleTypes from './exampleTypes'
 import lens from './lens'
 import mockService from './mockService'
 import subquery from './subquery'
+import { setupListeners } from './listeners'
 
 let shouldBlockUpdate = flat => {
   let leaves = Tree.flatLeaves(flat)
@@ -238,6 +239,9 @@ export let ContextTree = _.curry(
     TreeInstance.addActions(actions)
     TreeInstance.lens = lens(TreeInstance)
     TreeInstance.subquery = subquery(types, TreeInstance)
+    
+    setupListeners(TreeInstance)
+    
     return TreeInstance
   }
 )

--- a/src/index.js
+++ b/src/index.js
@@ -239,9 +239,9 @@ export let ContextTree = _.curry(
     TreeInstance.addActions(actions)
     TreeInstance.lens = lens(TreeInstance)
     TreeInstance.subquery = subquery(types, TreeInstance)
-    
+
     setupListeners(TreeInstance)
-    
+
     return TreeInstance
   }
 )

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -1,0 +1,15 @@
+let _ = require('lodash/fp')
+import { intersects, eventEmitter } from './util/futil'
+import { encode } from './util/tree'
+
+export let setupListeners = tree => {
+  let { on, emit } = eventEmitter()
+  // Assume first arg is node which might have path
+  tree.onChange = (node = {}, delta) => emit(encode(node.path), node, delta)
+  // Public API
+  tree.watchNode = (path, f, keys) =>
+    on(encode(path), (node, delta) => {
+      // Trigger watcher if keys match or no keys passed
+      if (!keys || intersects(keys, _.keys(delta))) f(node, delta)
+    })
+}

--- a/src/util/futil.js
+++ b/src/util/futil.js
@@ -5,8 +5,6 @@ export let intersects = (a, b) => !_.isEmpty(_.intersection(a, b))
 
 // Sets up basic event emitter/listener registry with an array of listeners per topic
 //  e.g. listeners: { topic1: [fn1, fn2, ...], topic2: [...], ... }
-// maybe better named pubsub with pub/sub methods?
-// also might be something off the shelf to use
 export let eventEmitter = (listeners = {}) => ({
     listeners,
     emit: (topic, ...args) => _.over(listeners[topic])(...args),

--- a/src/util/futil.js
+++ b/src/util/futil.js
@@ -1,0 +1,21 @@
+let _ = require('lodash/fp')
+
+// Sugar for checking non empty intersection
+export let intersects = (a, b) => !_.isEmpty(_.intersection(a, b))
+
+// Sets up basic event emitter/listener registry with an array of listeners per topic
+//  e.g. listeners: { topic1: [fn1, fn2, ...], topic2: [...], ... }
+// maybe better named pubsub with pub/sub methods?
+// also might be something off the shelf to use
+export let eventEmitter = (listeners = {}) => ({
+    listeners,
+    emit: (topic, ...args) => _.over(listeners[topic])(...args),
+    on: (topic, fn) => {
+      if (!listeners[topic]) listeners[topic] = []
+      listeners[topic].push(fn)
+      // unlisten
+      return () => {
+        listeners[topic] = _.without(fn, listeners[topic])
+      }
+    },
+  })

--- a/src/util/futil.js
+++ b/src/util/futil.js
@@ -6,14 +6,14 @@ export let intersects = (a, b) => !_.isEmpty(_.intersection(a, b))
 // Sets up basic event emitter/listener registry with an array of listeners per topic
 //  e.g. listeners: { topic1: [fn1, fn2, ...], topic2: [...], ... }
 export let eventEmitter = (listeners = {}) => ({
-    listeners,
-    emit: (topic, ...args) => _.over(listeners[topic])(...args),
-    on: (topic, fn) => {
-      if (!listeners[topic]) listeners[topic] = []
-      listeners[topic].push(fn)
-      // unlisten
-      return () => {
-        listeners[topic] = _.without(fn, listeners[topic])
-      }
-    },
-  })
+  listeners,
+  emit: (topic, ...args) => _.over(listeners[topic])(...args),
+  on(topic, fn) {
+    if (!listeners[topic]) listeners[topic] = []
+    listeners[topic].push(fn)
+    // unlisten
+    return () => {
+      listeners[topic] = _.without(fn, listeners[topic])
+    }
+  },
+})

--- a/test/index.js
+++ b/test/index.js
@@ -2092,7 +2092,7 @@ let AllTests = ContextureClient => {
     })
     expect(Tree.getNode(['root', 'pivot']).forceReplaceResponse).to.equal(true)
   })
-  it('should support watchNode', async() => {
+  it('should support watchNode', async () => {
     let service = sinon.spy(mockService())
     let Tree = ContextureClient(
       { service, debounce: 1 },
@@ -2116,7 +2116,7 @@ let AllTests = ContextureClient => {
     expect(resultWatcher).to.have.callCount(2)
     await Tree.mutate(['root', 'results'], { page: 2 })
     expect(resultWatcher).to.have.callCount(4)
-    
+
     await Tree.mutate(['root', 'test'], { values: ['asdf'] })
     expect(facetWatcher).to.have.callCount(1)
     // resultWatcher called twice more because facet change resets page to 0

--- a/test/index.js
+++ b/test/index.js
@@ -2092,6 +2092,36 @@ let AllTests = ContextureClient => {
     })
     expect(Tree.getNode(['root', 'pivot']).forceReplaceResponse).to.equal(true)
   })
+  it('should support watchNode', async() => {
+    let service = sinon.spy(mockService())
+    let Tree = ContextureClient(
+      { service, debounce: 1 },
+      {
+        key: 'root',
+        join: 'and',
+        children: [
+          { key: 'results', type: 'results', infiniteScroll: true },
+          { key: 'test', type: 'facet', values: [] },
+        ],
+      }
+    )
+    let resultWatcher = sinon.spy()
+    Tree.watchNode(['root', 'results'], resultWatcher, ['page', 'context'])
+    let facetWatcher = sinon.spy()
+    Tree.watchNode(['root', 'test'], facetWatcher, ['values'])
+
+    let promise = Tree.mutate(['root', 'results'], { page: 1 })
+    expect(resultWatcher).to.have.callCount(1)
+    await promise
+    expect(resultWatcher).to.have.callCount(2)
+    await Tree.mutate(['root', 'results'], { page: 2 })
+    expect(resultWatcher).to.have.callCount(4)
+    
+    await Tree.mutate(['root', 'test'], { values: ['asdf'] })
+    expect(facetWatcher).to.have.callCount(1)
+    // resultWatcher called twice more because facet change resets page to 0
+    expect(resultWatcher).to.have.callCount(6)
+  })
 }
 
 describe('lib', () => AllTests(ContextureClient))


### PR DESCRIPTION
Add `watchNode` API. Can be used to create a native react hook, dependency-free!

Here's a quick sketch:

```js
let useNode = (path, tree, keys = []) => {
  let [lastUpdate, setLastUpdate] = React.useState(new Date())
  useEffect(() => tree.watchNode(path, () => setLastUpdate(new Date()), keys))
  return tree.getNode(path)
}
```
then later:
```js
let NodeBlob = ({ tree, path }) => {
  let node = useNode(path, tree)
  return <pre>{JSON.stringify(node, 0, 2)}</pre>
}
```
or:
```js
let NodeBlob = ({ tree, path }) => {
  let node = useNode(path, tree, ['value', 'context'])
  return <pre>{JSON.stringify(node, 0, 2)}</pre>
}
```