### PR TITLE
Better pivot merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.39.2
+* Better `pivot` `mergeResponse` implementation that merges groups by key
+* Move from `futil-js` to `futil`
+
 # 2.39.1
 * Add node validation for `pivot` groups 
 * Add self reactor for a `pivot` node `drilldown` property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.39.2
 * Better `pivot` `mergeResponse` implementation that merges groups by key
 * Move from `futil-js` to `futil`
+* Pass `snapshot` into `mergeResponse` to avoid a mobx bug
 
 # 2.39.1
 * Add node validation for `pivot` groups 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "contexture-client",
-  "version": "2.39.0",
+  "version": "2.39.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.36.2",
+      "name": "contexture-client",
+      "version": "2.39.1",
       "license": "MIT",
       "dependencies": {
-        "futil-js": "^1.58.0",
-        "lodash": "^4.17.4"
+        "futil": "^1.69.0",
+        "lodash": "^4.17.15"
       },
       "devDependencies": {
         "babel-cli": "^6.26.0",
@@ -4681,10 +4682,20 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "node_modules/futil": {
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/futil/-/futil-1.69.0.tgz",
+      "integrity": "sha512-7UHnHv5yKfqfd5zZAjvVmVW9AkUW4d3oGDDwc4b/6WZWFB14uh5QRoHFBhisiwWWmGCMCTkUxh3ndQPr2ZTU7Q==",
+      "dependencies": {
+        "babel-polyfill": "^6.23.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "node_modules/futil-js": {
       "version": "1.65.0",
       "resolved": "https://registry.npmjs.org/futil-js/-/futil-js-1.65.0.tgz",
       "integrity": "sha512-VBZOzAQ3XYWhamk+h/dC16b82Z16NBQmL2gY3lu9XDt2BRzGeaIysxJDP0lKijxU5Y4U6KBpQL1gvOQhlAPQzQ==",
+      "dev": true,
       "dependencies": {
         "babel-polyfill": "^6.23.0",
         "lodash": "^4.17.4"
@@ -17962,10 +17973,20 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "futil": {
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/futil/-/futil-1.69.0.tgz",
+      "integrity": "sha512-7UHnHv5yKfqfd5zZAjvVmVW9AkUW4d3oGDDwc4b/6WZWFB14uh5QRoHFBhisiwWWmGCMCTkUxh3ndQPr2ZTU7Q==",
+      "requires": {
+        "babel-polyfill": "^6.23.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "futil-js": {
       "version": "1.65.0",
       "resolved": "https://registry.npmjs.org/futil-js/-/futil-js-1.65.0.tgz",
       "integrity": "sha512-VBZOzAQ3XYWhamk+h/dC16b82Z16NBQmL2gY3lu9XDt2BRzGeaIysxJDP0lKijxU5Y4U6KBpQL1gvOQhlAPQzQ==",
+      "dev": true,
       "requires": {
         "babel-polyfill": "^6.23.0",
         "lodash": "^4.17.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.39.1",
+  "version": "2.39.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.39.1",
+  "version": "2.39.2",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/smartprocure/contexture-client#readme",
   "dependencies": {
-    "futil-js": "^1.58.0",
-    "lodash": "^4.17.4"
+    "futil": "^1.69.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import F from 'futil-js'
+import F from 'futil'
 import { encode, Tree } from '../util/tree'
 import { getTypeProp } from '../types'
 import wrap from './wrap'

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -308,12 +308,14 @@ export default F.stampKey('type', {
     shouldMergeResponse: node => !_.isEmpty(node.drilldown),
     mergeResponse(node, response, extend, snapshot) {
       let transform = transformTreePostOrder(_.get('groups'))
-      
+
       // Convert response groups to objects for easy merges
       let groupsToObjects = transform(maybeUpdateOn('groups', _.keyBy('key')))
       // `snapshot` here is to solve a mobx issue
       // wrap in `groups` so it traverses the root level
-      let nodeGroups = groupsToObjects({ groups: snapshot(node.context.results) })
+      let nodeGroups = groupsToObjects({
+        groups: snapshot(node.context.results),
+      })
       let responseGroups = groupsToObjects({ groups: response.context.results })
       // Easy merge now that we can merge by group key
       let results = F.mergeAllArrays([nodeGroups, responseGroups])
@@ -322,7 +324,7 @@ export default F.stampKey('type', {
       let groupsToArrays = transform(maybeUpdateOn('groups', F.unkeyBy('key')))
       // Grab `groups` property we artifically added above for easy traversals
       let context = { results: groupsToArrays(results).groups }
-      
+
       // Write on the node
       extend(node, { context })
     },

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
+import F from 'futil'
 import { transformTreePostOrder, maybeUpdateOn } from './util/futil'
 
 let validateValues = ({ value, values = [] }) => value || values.length

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp'
 import * as F from 'futil-js'
+import { transformTreePostOrder, maybeUpdateOn } from './util/futil'
 
 let validateValues = ({ value, values = [] }) => value || values.length
 let validateValueExistence = _.flow(_.get('value'), _.negate(_.isNil))
@@ -305,8 +306,24 @@ export default F.stampKey('type', {
       }
     },
     shouldMergeResponse: node => !_.isEmpty(node.drilldown),
-    mergeResponse(node, response, extend) {
-      let context = F.mergeAllArrays([node.context, response.context])
+    mergeResponse(node, response, extend, snapshot) {
+      let transform = transformTreePostOrder(_.get('groups'))
+      
+      // Convert response groups to objects for easy merges
+      let groupsToObjects = transform(maybeUpdateOn('groups', _.keyBy('key')))
+      // `snapshot` here is to solve a mobx issue
+      // wrap in `groups` so it traverses the root level
+      let nodeGroups = groupsToObjects({ groups: snapshot(node.context.results) })
+      let responseGroups = groupsToObjects({ groups: response.context.results })
+      // Easy merge now that we can merge by group key
+      let results = F.mergeAllArrays([nodeGroups, responseGroups])
+
+      // Convert groups back to arrays
+      let groupsToArrays = transform(maybeUpdateOn('groups', F.unkeyBy('key')))
+      // Grab `groups` property we artifically added above for easy traversals
+      let context = { results: groupsToArrays(results).groups }
+      
+      // Write on the node
       extend(node, { context })
     },
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
+import F from 'futil'
 import { flatten, bubbleUp, Tree, encode, decode, isParent } from './util/tree'
 import { validate } from './validation'
 import { getAffectedNodes, reactors } from './reactors'

--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,12 @@ export let ContextTree = _.curry(
             !target.forceReplaceResponse &&
             F.maybeCall(typeProp('shouldMergeResponse', target), target)
           )
-            typeProp('mergeResponse', target)(target, responseNode, extend, snapshot)
+            typeProp('mergeResponse', target)(
+              target,
+              responseNode,
+              extend,
+              snapshot
+            )
           else {
             target.forceReplaceResponse = false
             extend(target, responseNode)

--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ export let ContextTree = _.curry(
             !target.forceReplaceResponse &&
             F.maybeCall(typeProp('shouldMergeResponse', target), target)
           )
-            typeProp('mergeResponse', target)(target, responseNode, extend)
+            typeProp('mergeResponse', target)(target, responseNode, extend, snapshot)
           else {
             target.forceReplaceResponse = false
             extend(target, responseNode)

--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import F from 'futil-js'
+import F from 'futil'
 import { Tree, encode } from './util/tree'
 import { runTypeFunction, runTypeFunctionOrDefault, getTypeProp } from './types'
 

--- a/src/reactors.js
+++ b/src/reactors.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
+import F from 'futil'
 import { hasContext, hasValue } from './node'
 
 let all = parent => _.toArray(parent.children)

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -1,4 +1,4 @@
-import * as F from 'futil-js'
+import F from 'futil'
 import { Tree } from './util/tree'
 
 export default extend => ({

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
+import F from 'futil'
 
 // Gets type a specific property from any of the places it might be - on the type in `types`, on default in `types`, or already on the node itself
 export let getTypeProp = _.curry(

--- a/src/util/futil.js
+++ b/src/util/futil.js
@@ -1,0 +1,13 @@
+import _ from 'lodash/fp'
+import * as F from 'futil-js'
+
+export let transformTreePostOrder = (next = F.traverse) =>
+  _.curry((f, x) => {
+    let result = _.cloneDeep(x)
+    F.walk(next)(_.noop, f)(result)
+    return result
+  })
+
+export let maybeUpdateOn = _.curry((key, fn, data) => {
+  if (_.get(key, data)) F.updateOn(key, fn, data)
+})

--- a/src/util/futil.js
+++ b/src/util/futil.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
+import F from 'futil'
 
 export let transformTreePostOrder = (next = F.traverse) =>
   _.curry((f, x) => {

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -1,4 +1,4 @@
-import * as F from 'futil-js'
+import F from 'futil'
 import _ from 'lodash/fp'
 
 export let promisedProps =

--- a/src/util/tree.js
+++ b/src/util/tree.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import * as F from 'futil-js'
+import F from 'futil'
 
 export let Tree = F.tree(
   _.get('children'),

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -2,7 +2,7 @@
 // No, we don't know why. We're sorry. #hackathon
 
 import { Tree } from '../src/util/tree'
-import * as F from 'futil-js'
+import F from 'futil'
 import _ from 'lodash/fp'
 import chai from 'chai'
 import sinon from 'sinon'

--- a/test/index.js
+++ b/test/index.js
@@ -2082,48 +2082,16 @@ let AllTests = ContextureClient => {
     )
     let node = Tree.getNode(['root', 'pivot'])
 
-    let merge = exampleTypes.pivot.mergeResponse
-    merge(
-      node,
-      {
-        context: {
-          results: [
-            { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-            { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
-          ],
-        },
-      },
-      Tree.extend,
-      Tree.snapshot
-    )
-    merge(
-      node,
-      {
-        context: {
-          results: [
-            {
-              key: 'NV',
-              groups: [
-                { key: 'nv2', b: 1 },
-                { key: 'nv1', a: 2 },
-              ],
-            },
-          ],
-        },
-      },
-      Tree.extend,
-      Tree.snapshot
-    )
+    let merge = results => exampleTypes.pivot.mergeResponse(node, {context: {results}}, Tree.extend, Tree.snapshot)
+    merge([
+      { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
+      { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
+    ])
+    merge([{ key: 'NV', groups: [{ key: 'nv2', b: 1 }, { key: 'nv1', a: 2 }]}])
 
     expect(node.context.results).to.deep.equal([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-      {
-        key: 'NV',
-        groups: [
-          { key: 'nv1', a: 2 },
-          { key: 'nv2', b: 1 },
-        ],
-      },
+      { key: 'NV', groups: [{ key: 'nv1', a: 2 }, { key: 'nv2', b: 1 }] },
     ])
   })
   it('should support onDispatch (and pivot overriding response merges)', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2094,24 +2094,12 @@ let AllTests = ContextureClient => {
       { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
     ])
     merge([
-      {
-        key: 'NV',
-        groups: [
-          { key: 'nv2', b: 1 },
-          { key: 'nv1', a: 2 },
-        ],
-      },
+      { key: 'NV', groups: [{ key: 'nv2', b: 1 }, { key: 'nv1', a: 2 }] },
     ])
 
     expect(node.context.results).to.deep.equal([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-      {
-        key: 'NV',
-        groups: [
-          { key: 'nv1', a: 2 },
-          { key: 'nv2', b: 1 },
-        ],
-      },
+      { key: 'NV', groups: [{ key: 'nv1', a: 2 }, { key: 'nv2', b: 1 }] },
     ])
   })
   it('should support onDispatch (and pivot overriding response merges)', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2083,25 +2083,47 @@ let AllTests = ContextureClient => {
     let node = Tree.getNode(['root', 'pivot'])
 
     let merge = exampleTypes.pivot.mergeResponse
-    merge(node, {
-      context: {
-        results: [
-          { key: 'FL', groups: [{ key: 'fl1', a: 1 }]},
-          { key: 'NV', groups: [{ key: 'nv1', a: 1 }]}
-        ]
-      }
-    }, Tree.extend, Tree.snapshot)
-    merge(node, {
-      context: {
-        results: [
-          { key: 'NV', groups: [{ key: 'nv2', b: 1 }, { key: 'nv1', a: 2 }]}
-        ]
-      }
-    }, Tree.extend, Tree.snapshot)
+    merge(
+      node,
+      {
+        context: {
+          results: [
+            { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
+            { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
+          ],
+        },
+      },
+      Tree.extend,
+      Tree.snapshot
+    )
+    merge(
+      node,
+      {
+        context: {
+          results: [
+            {
+              key: 'NV',
+              groups: [
+                { key: 'nv2', b: 1 },
+                { key: 'nv1', a: 2 },
+              ],
+            },
+          ],
+        },
+      },
+      Tree.extend,
+      Tree.snapshot
+    )
 
     expect(node.context.results).to.deep.equal([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-      { key: 'NV', groups: [{ key: 'nv1', a: 2 }, { key: 'nv2', b: 1 }] }
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv1', a: 2 },
+          { key: 'nv2', b: 1 },
+        ],
+      },
     ])
   })
   it('should support onDispatch (and pivot overriding response merges)', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2082,16 +2082,36 @@ let AllTests = ContextureClient => {
     )
     let node = Tree.getNode(['root', 'pivot'])
 
-    let merge = results => exampleTypes.pivot.mergeResponse(node, {context: {results}}, Tree.extend, Tree.snapshot)
+    let merge = results =>
+      exampleTypes.pivot.mergeResponse(
+        node,
+        { context: { results } },
+        Tree.extend,
+        Tree.snapshot
+      )
     merge([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
       { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
     ])
-    merge([{ key: 'NV', groups: [{ key: 'nv2', b: 1 }, { key: 'nv1', a: 2 }]}])
+    merge([
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv2', b: 1 },
+          { key: 'nv1', a: 2 },
+        ],
+      },
+    ])
 
     expect(node.context.results).to.deep.equal([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-      { key: 'NV', groups: [{ key: 'nv1', a: 2 }, { key: 'nv2', b: 1 }] },
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv1', a: 2 },
+          { key: 'nv2', b: 1 },
+        ],
+      },
     ])
   })
   it('should support onDispatch (and pivot overriding response merges)', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2094,12 +2094,24 @@ let AllTests = ContextureClient => {
       { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
     ])
     merge([
-      { key: 'NV', groups: [{ key: 'nv2', b: 1 }, { key: 'nv1', a: 2 }] },
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv2', b: 1 },
+          { key: 'nv1', a: 2 },
+        ],
+      },
     ])
 
     expect(node.context.results).to.deep.equal([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-      { key: 'NV', groups: [{ key: 'nv1', a: 2 }, { key: 'nv2', b: 1 }] },
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv1', a: 2 },
+          { key: 'nv2', b: 1 },
+        ],
+      },
     ])
   })
   it('should support onDispatch (and pivot overriding response merges)', async () => {


### PR DESCRIPTION
* Better `pivot` `mergeResponse` implementation that merges groups by key
* Move from `futil-js` to `futil`

Closes #162 