### PR TITLE
Snapshot type defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.39.3
+* Fix: Use `snapshot` on `typeDefaults` instead of `_.deepClone` to fix regression from `2.38.0` for real world apps that end up with observable `typeDefaults`
+
 # 2.39.2
 * Better `pivot` `mergeResponse` implementation that merges groups by key
 * Move from `futil-js` to `futil`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -34,7 +34,7 @@ export default config => {
 
     dedupeWalk(
       (dedupe, parentPath, node) => {
-        initNode(extend, types, dedupe, parentPath, node)
+        initNode({ extend, types, snapshot }, dedupe, parentPath, node)
         flat[encode(node.path)] = node
       },
       node,

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ export let ContextTree = _.curry(
     let customReactors = reactors
 
     // initNode now generates node keys, so it must be run before flattening the tree
-    dedupeWalk(initNode(extend, types), tree)
+    dedupeWalk(initNode({ extend, types, snapshot }), tree)
     let flat = flatten(tree)
     let getNode = path => flat[encode(path)]
 

--- a/src/node.js
+++ b/src/node.js
@@ -28,7 +28,7 @@ export let internalStateKeys = {
 
 export let autoKey = x => F.compactJoin('-', [x.field, x.type]) || 'node'
 
-export let initNode = _.curry((extend, types, dedupe, parentPath, node) => {
+export let initNode = _.curry(({ extend, types, snapshot }, dedupe, parentPath, node) => {
   runTypeFunction(types, 'init', node, extend)
   let key = dedupe(
     node.key ||
@@ -36,7 +36,8 @@ export let initNode = _.curry((extend, types, dedupe, parentPath, node) => {
   )
   extend(node, {
     ..._.omit(_.keys(node), defaults),
-    ..._.omit(_.keys(node), _.cloneDeep(getTypeProp(types, 'defaults', node))),
+    // For some reason, type defaults can end up observable in real world apps, so we `snapshot` instead of `_.deepClone`
+    ..._.omit(_.keys(node), snapshot(getTypeProp(types, 'defaults', node))),
     key,
     path: [...parentPath, key],
   })

--- a/src/node.js
+++ b/src/node.js
@@ -28,20 +28,22 @@ export let internalStateKeys = {
 
 export let autoKey = x => F.compactJoin('-', [x.field, x.type]) || 'node'
 
-export let initNode = _.curry(({ extend, types, snapshot }, dedupe, parentPath, node) => {
-  runTypeFunction(types, 'init', node, extend)
-  let key = dedupe(
-    node.key ||
-      runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, extend)
-  )
-  extend(node, {
-    ..._.omit(_.keys(node), defaults),
-    // For some reason, type defaults can end up observable in real world apps, so we `snapshot` instead of `_.deepClone`
-    ..._.omit(_.keys(node), snapshot(getTypeProp(types, 'defaults', node))),
-    key,
-    path: [...parentPath, key],
-  })
-})
+export let initNode = _.curry(
+  ({ extend, types, snapshot }, dedupe, parentPath, node) => {
+    runTypeFunction(types, 'init', node, extend)
+    let key = dedupe(
+      node.key ||
+        runTypeFunctionOrDefault(autoKey, types, 'autoKey', node, extend)
+    )
+    extend(node, {
+      ..._.omit(_.keys(node), defaults),
+      // For some reason, type defaults can end up observable in real world apps, so we `snapshot` instead of `_.deepClone`
+      ..._.omit(_.keys(node), snapshot(getTypeProp(types, 'defaults', node))),
+      key,
+      path: [...parentPath, key],
+    })
+  }
+)
 
 // fn: (dedupe: string -> string, parentPath: array, node: object) -> void
 export let dedupeWalk = (fn, tree, { target = {}, dedupe } = {}) => {

--- a/test/index.js
+++ b/test/index.js
@@ -2094,12 +2094,24 @@ let AllTests = ContextureClient => {
       { key: 'NV', groups: [{ key: 'nv1', a: 1 }] },
     ])
     merge([
-      { key: 'NV', groups: [{ key: 'nv2', b: 1 }, { key: 'nv1', a: 2 }] },
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv2', b: 1 },
+          { key: 'nv1', a: 2 },
+        ],
+      },
     ])
 
     expect(node.context.results).to.deep.equal([
       { key: 'FL', groups: [{ key: 'fl1', a: 1 }] },
-      { key: 'NV', groups: [{ key: 'nv1', a: 2 }, { key: 'nv2', b: 1 }] },
+      {
+        key: 'NV',
+        groups: [
+          { key: 'nv1', a: 2 },
+          { key: 'nv2', b: 1 },
+        ],
+      },
     ])
   })
   it('should support onDispatch (and pivot overriding response merges)', async () => {


### PR DESCRIPTION
Fix: Use `snapshot` on `typeDefaults` instead of `_.deepClone` to fix regression from `2.38.0` for real world apps that end up with observable `typeDefaults`

This really shouldn't be a thing, but it's reasonable since the premise of `mobx` utilization at the moment is to just have everything observable. This hastens #169 since we can drastically simplify things by just expose observability from the client and obviating the need for mobx (even in apps using it already).

Note: for anyone using the undocumented `initNode` method directly, this would be a breaking change since `initNode` now takes an object of `{ extend, types, snapshot }` instead of `extend` and `types` as the first two curried arguments. This would only affect users of the experimental `addActions` API, of which there are no known usages (since contexture-react dropped it's usage in https://github.com/smartprocure/contexture-react/pull/222 back in 2019)