### PR TITLE
Deprecate flat tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 2.43.0
+# 2.44.0
+* Add `isStale`, sugar for `markedForUpdate || updating`
+* Node flags `isStale`, `markedForUpdate`, and `updating` are now properly set at the group level as whether any of their children have them set
+* Deprecated undocumented internal `flat` tree, will remove in next version
 * Remove unused `default` type support
 
 # 2.43.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Deprecated undocumented internal `flat` tree, will remove in next version
 * Remove unused `default` type support
 * `watchNode` now supports nested paths (e.g. `context.something`) and empty keys array
+* Actions now recieve a full `TreeInstance` instead of just action props
 
 # 2.43.0
 * Add `watchNode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Node flags `isStale`, `markedForUpdate`, and `updating` are now properly set at the group level as whether any of their children have them set
 * Deprecated undocumented internal `flat` tree, will remove in next version
 * Remove unused `default` type support
+* `watchNode` now supports nested paths (e.g. `context.something`) and empty keys array
 
 # 2.43.0
 * Add `watchNode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 2.43.0
+* Remove unused `default` type support
+
+# 2.43.0
 * Add `watchNode`
 
 # 2.42.0

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following config options are available:
 | service           | function                       | n/a          | **Required** Async function to actually get service results (from the contexture core). An exception will be thrown if this is not passed in. |
 | types             | ClientTypeSpec                 | exampleTypes | Configuration of available types (documented below) |
 | debounce          | number                         | 1            | How many milliseconds to globally debounce search. Does not apply when `disableAutoUpdates` is true. |
-| onChange          | (node, changes) => {}          |  _.noop      | A hook to capture when the client changes any property on a node. Can be modified at run time by reassigning the property on a tree instance. |
+| onChange          | (node, changes) => {}          |  _.noop      | A hook to capture when the client changes any property on a node. Can be modified at run time by reassigning the property on a tree instance. Generally only for internal use - if you're looking for this, you probably want `watchNode` |
 | onResult          | (path, response, target) => {} |  _.noop      | A hook to capture when the client updates a node with results from the server. Can be modified at run time by reassigning the property on a tree instance. |
 | debug             | boolean                        | false        | Debug mode will log all dispatched events and generally help debugging |
 | extend            | function                       | F.extendOn   | Used to mutate nodes internally |
@@ -140,7 +140,7 @@ The following methods are exposed on an instantiated client:
 | subquery | `(targetPath, sourceTree, sourcePath, mapSubqueryValues?) => {}` | Sets up a subquery, using the types passed in to the client and assuming this tree instance is the target tree. For more info, see the [subquery](#Subquery) section below. |
 | isPausedNested | `path -> bool` | Returns a bool for whether the node at the path and all of its children are paused. |
 | processResponseNode | `(path, node) => {}` | Used to process intermediate partial results from the server |
-| watchNode | `(path, watcherFn, [keys]) => {}` | Runs `watcherFn` any time the node at `path` is updated, optionally restricted to the array of keys passed in. `watcherFn` is called with `(node, delta)` which is a reference to the target node and the payload to update it with. Useful for implementing observability, e.g. a react hook. |
+| watchNode | `(path, watcherFn, [keys]) => {}` | Runs `watcherFn` any time the node at `path` is updated, optionally restricted to the array of keys passed in. `watcherFn` is called with `(node, delta)` which is a reference to the target node and the payload to update it with. Keys may be nested (e.g. `context.something`). Keys are not cloned, so you can retain a reference and mutate the keys array to change what's being observed at runtime. Useful for implementing observability, e.g. a react hook. |
 
 #### Actions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -26,7 +26,7 @@ export default config => {
     onChange,
   } = config
 
-  let add = async (parentPath, node, { index } = {}) => {
+  let add = (parentPath, node, { index } = {}) => {
     let target = getNode(parentPath)
     // initialize uniqueString cache for the parent of the node to be added here,
     // since it's not visited during the tree walk
@@ -51,7 +51,7 @@ export default config => {
     return dispatch({ type: 'add', path: _.toArray(node.path), node })
   }
 
-  let remove = async path => {
+  let remove = path => {
     let previous = getNode(path)
     let parentPath = arrayDropLast(path)
     let parent = getNode(parentPath)
@@ -66,7 +66,7 @@ export default config => {
     return dispatch({ type: 'remove', path, previous })
   }
 
-  let mutate = _.curry(async (path, value) => {
+  let mutate = _.curry((path, value) => {
     let target = getNode(path)
     let previous = snapshot(_.omit('children', target))
     extend(target, value)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -23,6 +23,7 @@ export default config => {
     extend,
     initNode,
     initObject,
+    onChange,
   } = config
 
   let add = async (parentPath, node, { index } = {}) => {
@@ -43,6 +44,7 @@ export default config => {
 
     // consider moving this in the tree walk? it could work for al children too but would be exgra work for chilren
     pushOrSpliceOn(target.children, node, index)
+    onChange(target, { children: target.children })
     // Need this nonsense to support the case where push actually mutates, e.g. a mobx observable tree
     // flat[encode(path)] = target.children[index]
 
@@ -54,6 +56,7 @@ export default config => {
     let parentPath = arrayDropLast(path)
     let parent = getNode(parentPath)
     F.pullOn(previous, parent.children)
+    onChange(parent, { children: parent.children })
 
     Tree.walk((node, index, [parent = {}]) => {
       let path = [...(parent.path || parentPath), node.key]
@@ -107,6 +110,7 @@ export default config => {
       // Same group, no dispatch or updating of paths needed - just rearrange children
       F.pullOn(node, getNode(parentPath).children)
       pushOrSpliceOn(getNode(targetPath).children, node, targetIndex)
+      onChange(node, { children: node.children })
     } else {
       return Promise.all([
         remove(path),

--- a/src/actions/wrap.js
+++ b/src/actions/wrap.js
@@ -29,13 +29,13 @@ export default ({ getNode, flat }, { mutate, replace, remove, add }) => {
     // Add original root as a child of the new root
     await add([newNode.key], node)
   }
-  let wrapInGroupReplace = async (path, newNode) =>
+  let wrapInGroupReplace = (path, newNode) =>
     replace(path, {
       ...newNode,
       children: [getNode(path)],
     })
 
-  let wrapInGroup = async (path, newNode) =>
+  let wrapInGroup = (path, newNode) =>
     _.size(path) > 1
       ? wrapInGroupReplace(path, newNode)
       : wrapInGroupInPlace(path, newNode)

--- a/src/index.js
+++ b/src/index.js
@@ -93,10 +93,11 @@ export let ContextTree = _.curry(
         // Mark children only if it's not a parent of the target so we don't incorrectly mark siblings
         // flatMap because traversing children can create arrays
         _.flatMap(n =>
-          F.unless(
+         F.unless(
             isParent(snapshot(n.path), event.path),
-            Tree.toArrayBy
-          )(markForUpdate)(n)
+            Tree.toArrayBy,
+            markForUpdate
+          )(n)
         )
       )(event, path)
 

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,12 @@ export let ContextTree = _.curry(
     extend = _.over([extend, (a, b) => TreeInstance.onChange(a, b)])
 
     // Getting the Traversals
-    let { markForUpdate, markLastUpdate, prepForUpdate } = traversals(extend)
+    let {
+      markForUpdate,
+      markLastUpdate,
+      prepForUpdate,
+      clearUpdate,
+    } = traversals(extend)
     let typeProp = getTypeProp(types)
 
     let processEvent = event => path =>
@@ -161,7 +166,7 @@ export let ContextTree = _.curry(
         // Clear updating
         Tree.walk(node => {
           if (node.updating) {
-            extend(node, { updating: false })
+            clearUpdate(node)
             node.updatingDeferred.resolve()
           }
         })(tree)
@@ -217,7 +222,7 @@ export let ContextTree = _.curry(
           if (debug && node._meta) target.metaHistory.push(node._meta)
         }
 
-        extend(target, { updating: false })
+        clearUpdate(target)
 
         if (!_.isEmpty(responseNode)) {
           try {

--- a/src/index.js
+++ b/src/index.js
@@ -261,19 +261,18 @@ export let ContextTree = _.curry(
       tree,
       debugInfo,
       ...actionProps,
-      addActions: create => F.extendOn(TreeInstance, create(actionProps)),
       addReactors: create => F.extendOn(customReactors, create()),
       onResult,
       onChange,
       disableAutoUpdate,
       processResponseNode,
     })
-
+    setupListeners(TreeInstance)
+    TreeInstance.addActions = create => F.extendOn(TreeInstance, create(TreeInstance)),
     TreeInstance.addActions(actions)
     TreeInstance.lens = lens(TreeInstance)
     TreeInstance.subquery = subquery(types, TreeInstance)
 
-    setupListeners(TreeInstance)
 
     return TreeInstance
   }

--- a/src/index.js
+++ b/src/index.js
@@ -268,11 +268,11 @@ export let ContextTree = _.curry(
       processResponseNode,
     })
     setupListeners(TreeInstance)
-    TreeInstance.addActions = create => F.extendOn(TreeInstance, create(TreeInstance)),
-    TreeInstance.addActions(actions)
+    ;(TreeInstance.addActions = create =>
+      F.extendOn(TreeInstance, create(TreeInstance))),
+      TreeInstance.addActions(actions)
     TreeInstance.lens = lens(TreeInstance)
     TreeInstance.subquery = subquery(types, TreeInstance)
-
 
     return TreeInstance
   }

--- a/src/index.js
+++ b/src/index.js
@@ -268,9 +268,9 @@ export let ContextTree = _.curry(
       processResponseNode,
     })
     setupListeners(TreeInstance)
-    ;(TreeInstance.addActions = create =>
-      F.extendOn(TreeInstance, create(TreeInstance))),
-      TreeInstance.addActions(actions)
+    TreeInstance.addActions = create =>
+      F.extendOn(TreeInstance, create(TreeInstance))
+    TreeInstance.addActions(actions)
     TreeInstance.lens = lens(TreeInstance)
     TreeInstance.subquery = subquery(types, TreeInstance)
 

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,10 @@ export let ContextTree = _.curry(
     // initNode now generates node keys, so it must be run before flattening the tree
     dedupeWalk(initNode({ extend, types, snapshot }), tree)
     let flat = flatten(tree)
-    let getNode = path => flat[encode(path)]
+    let getNode = path =>
+      // empty path returns root with tree lookup, but should be undefined to mimic flat tree
+      !_.isEmpty(path) && Tree.lookup(_.drop(1, path), tree)
+    //  flat[encode(path)]
 
     // Overwrite extend to report changes
     extend = _.over([extend, (a, b) => TreeInstance.onChange(a, b)])

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import { setupListeners } from './listeners'
 
 let shouldBlockUpdate = tree => {
   let leaves = Tree.leaves(tree)
-  let noUpdates = !_.some('markedForUpdate', leaves)
+  let noUpdates = !tree.markedForUpdate
   let hasErrors = _.some('error', leaves)
   return hasErrors || noUpdates
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,14 @@
 import _ from 'lodash/fp'
 import F from 'futil'
-import { flatten, bubbleUp, Tree, encode, decode, isParent } from './util/tree'
+import {
+  flatten,
+  bubbleUp,
+  Tree,
+  encode,
+  decode,
+  isParent,
+  pathFromParents,
+} from './util/tree'
 import { validate } from './validation'
 import { getAffectedNodes, reactors } from './reactors'
 import actions from './actions'
@@ -138,7 +146,7 @@ export let ContextTree = _.curry(
       // make all other nodes filter only
       if (path) {
         Tree.walk((node, index, parents) => {
-          let nodePath = [..._.map('key', _.reverse(parents)), node.key]
+          let nodePath = pathFromParents(parents, node)
           // marking everything that isn’t the node or it’s children
           if (!_.isEqual(path, nodePath) && !isParent(path, nodePath)) {
             node.filterOnly = true
@@ -181,11 +189,8 @@ export let ContextTree = _.curry(
       data = _.isEmpty(data.data) ? data : data.data
       let { error } = data
       if (error) extend(tree, { error })
-      await Tree.walkAsync(
-        async (node, i, parents) => {
-          let path = _.map('key', [..._.reverse(parents), node])
-          return processResponseNode(path, node)
-        }
+      await Tree.walkAsync(async (node, i, parents) =>
+        processResponseNode(pathFromParents(parents, node), node)
       )(data)
     }
     let processResponseNode = async (path, node) => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ import mockService from './mockService'
 import subquery from './subquery'
 import { setupListeners } from './listeners'
 
-let shouldBlockUpdate = flat => {
-  let leaves = Tree.flatLeaves(flat)
+let shouldBlockUpdate = tree => {
+  let leaves = Tree.leaves(tree)
   let noUpdates = !_.some('markedForUpdate', leaves)
   let hasErrors = _.some('error', leaves)
   return hasErrors || noUpdates
@@ -124,7 +124,7 @@ export let ContextTree = _.curry(
 
     // If specifying path, *only* update that path
     let runUpdate = async path => {
-      if (shouldBlockUpdate(flat)) return log('Blocked Search')
+      if (shouldBlockUpdate(tree)) return log('Blocked Search')
       let now = new Date().getTime()
       let node = getNode(path)
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ let shouldBlockUpdate = tree => {
   return hasErrors || noUpdates
 }
 
-let isStale = (result, target) =>
+let isStaleResult = (result, target) =>
   target.lastUpdateTime &&
   result.lastUpdateTime &&
   target.lastUpdateTime > result.lastUpdateTime
@@ -197,7 +197,7 @@ export let ContextTree = _.curry(
     let processResponseNode = async (path, node) => {
       let target = getNode(path)
       let responseNode = _.pick(['context', 'error'], node)
-      if (target && !isStale(node, target)) {
+      if (target && !isStaleResult(node, target)) {
         if (!_.isEmpty(responseNode)) {
           TreeInstance.onResult(path, node, target)
           if (

--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,7 @@ export let ContextTree = _.curry(
       )
     }
     let processResponseNode = async (path, node) => {
-      let target = flat[encode(path)]
+      let target = getNode(path)
       let responseNode = _.pick(['context', 'error'], node)
       if (target && !isStale(node, target)) {
         if (!_.isEmpty(responseNode)) {

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export let ContextTree = _.curry(
         // flatMap because traversing children can create arrays
         // groups that aren't properly marked here are taken care of by syncMarkedForUpdate right after
         _.flatMap(n =>
-         F.unless(
+          F.unless(
             isParent(snapshot(n.path), event.path),
             Tree.toArrayBy,
             markForUpdate
@@ -120,7 +120,7 @@ export let ContextTree = _.curry(
         // Get updated nodes
         ..._.flatten(bubbleUp(processEvent(event), event.path)),
         // Get nodes updated as a result of the sync
-        ...syncMarkedForUpdate(tree)
+        ...syncMarkedForUpdate(tree),
       ]
 
       await Promise.all(_.invokeMap('onMarkForUpdate', updatedNodes))

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -1,5 +1,5 @@
 let _ = require('lodash/fp')
-import { intersects, eventEmitter } from './util/futil'
+import { eventEmitter, hasSome } from './util/futil'
 import { encode } from './util/tree'
 
 export let setupListeners = tree => {
@@ -8,8 +8,9 @@ export let setupListeners = tree => {
   tree.onChange = (node = {}, delta) => emit(encode(node.path), node, delta)
   // Public API
   tree.watchNode = (path, f, keys) =>
-    on(encode(path), (node, delta) => {
+    on(encode(path), (path, node, delta) => {
       // Trigger watcher if keys match or no keys passed
-      if (!keys || intersects(keys, _.keys(delta))) f(node, delta)
+      if (_.isEmpty(keys) || hasSome(keys, delta)) f(node, delta)
+    })
     })
 }

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -8,7 +8,7 @@ export let setupListeners = tree => {
   tree.onChange = (node = {}, delta) => emit(encode(node.path), node, delta)
   // Public API
   tree.watchNode = (path, f, keys) =>
-    on(encode(path), (path, node, delta) => {
+    on(encode(path), (node, delta) => {
       // Trigger watcher if keys match or no keys passed
       if (_.isEmpty(keys) || hasSome(keys, delta)) f(node, delta)
     })

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -12,5 +12,4 @@ export let setupListeners = tree => {
       // Trigger watcher if keys match or no keys passed
       if (_.isEmpty(keys) || hasSome(keys, delta)) f(node, delta)
     })
-    })
 }

--- a/src/mockService.js
+++ b/src/mockService.js
@@ -1,4 +1,5 @@
-import * as F from 'futil-js'
+import Promise from 'bluebird'
+import F from 'futil'
 import { Tree } from './util/tree'
 
 export let defaultMocks = ({ type }) =>
@@ -16,10 +17,13 @@ export let defaultMocks = ({ type }) =>
     },
   }[type])
 
-export default ({ mocks = defaultMocks, logInput, logOutput } = {}) => (
-  dto,
-  lastUpdateTime
-) => {
+export default ({
+  mocks = defaultMocks,
+  logInput,
+  logOutput,
+  delay,
+} = {}) => async (dto, lastUpdateTime) => {
+  if (delay) await Promise.delay(delay)
   if (logInput) console.info('dto', JSON.stringify(dto, 0, 2))
   let result = Tree.transform(node => {
     let context = mocks(node)

--- a/src/node.js
+++ b/src/node.js
@@ -4,6 +4,8 @@ import { Tree, encode } from './util/tree'
 import { runTypeFunction, runTypeFunctionOrDefault, getTypeProp } from './types'
 
 export let defaults = {
+  type: null,
+  paused: null,
   path: null,
   updating: null,
   lastUpdateTime: null,
@@ -12,19 +14,17 @@ export let defaults = {
   error: null,
   context: null,
   missedUpdate: null,
-  paused: null,
-  type: null,
   updatingPromise: null,
   updatingDeferred: null,
   metaHistory: [],
 }
-export let internalStateKeys = {
-  ..._.omit(['type', 'paused'], defaults),
-  validate: null,
-  onMarkForUpdate: null,
-  afterSearch: null,
-  forceReplaceResponse: false,
-}
+export let internalStateKeys = [
+  ..._.keys(_.omit(['type', 'paused'], defaults)),
+  'validate',
+  'onMarkForUpdate',
+  'afterSearch',
+  'forceReplaceResponse',
+]
 
 export let autoKey = x => F.compactJoin('-', [x.field, x.type]) || 'node'
 

--- a/src/node.js
+++ b/src/node.js
@@ -10,6 +10,7 @@ export let defaults = {
   updating: null,
   lastUpdateTime: null,
   markedForUpdate: null,
+  isStale: null,
   hasValue: null,
   error: null,
   context: null,

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -11,7 +11,7 @@ export default (tree, { search } = {}) =>
     Tree.walk(x => {
       if (search && isFilterOnly(x)) x.filterOnly = true
       _.each(unsetOn(_, x), [
-        ..._.keys(_.omit(search ? 'lastUpdateTime' : '', internalStateKeys)),
+        ..._.without(search && ['lastUpdateTime'], internalStateKeys),
         ...getNilKeys(x),
       ])
     }),

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -1,4 +1,5 @@
 import F from 'futil'
+import _ from 'lodash/fp'
 import { Tree } from './util/tree'
 
 export default extend => {
@@ -18,6 +19,27 @@ export default extend => {
   return {
     markForUpdate,
     clearUpdate: node => extend(node, { updating: false, isStale: false }),
+    syncMarkedForUpdate: tree => {
+      // This method is to sync markedForUpdate/isStale
+      //  in theory this could be a getter/setter or writeableComputed
+      //  syncing manually avoids taking on a dependency like mobx in the core
+
+      // This walk/push will be replaced in the future by Tree.toArrayBy({ post: /* ... */})
+      let updatedNodes = []
+      Tree.walk(
+        () => {},
+        node => {
+          if (_.some('markedForUpdate', node.children))
+            updatedNodes.push(markForUpdate(node))
+          else if (node.children)
+            extend(node, {
+              markedForUpdate: false,
+              ...(node.updating || { isStale: false }),
+            })
+        }
+      )(tree)
+      return updatedNodes
+    },
     markLastUpdate: time =>
       Tree.walk(node => {
         if (node.markedForUpdate) extend(node, { lastUpdateTime: time })

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -19,7 +19,7 @@ export default extend => {
   return {
     markForUpdate,
     clearUpdate: node => extend(node, { updating: false, isStale: false }),
-    syncMarkedForUpdate: tree => {
+    syncMarkedForUpdate(tree) {
       // This method is to sync markedForUpdate/isStale
       //  in theory this could be a getter/setter or writeableComputed
       //  syncing manually avoids taking on a dependency like mobx in the core

--- a/src/types.js
+++ b/src/types.js
@@ -1,10 +1,9 @@
 import _ from 'lodash/fp'
 import F from 'futil'
 
-// Gets type a specific property from any of the places it might be - on the type in `types`, on default in `types`, or already on the node itself
+// Gets type a specific property from any of the places it might be - on the type in `types` or already on the node itself
 export let getTypeProp = _.curry(
-  (types, prop, node) =>
-    node[prop] || F.cascade([`${node.type}.${prop}`, `default.${prop}`], types)
+  (types, prop, node) => node[prop] || _.get(`${node.type}.${prop}`, types)
 )
 
 // Same as getTypeProp, but throws instead of returning undefined if it's missing

--- a/src/util/futil.js
+++ b/src/util/futil.js
@@ -3,6 +3,7 @@ import F from 'futil'
 
 // Sugar for checking non empty intersection
 export let intersects = (a, b) => !_.isEmpty(_.intersection(a, b))
+export let hasSome = (keys, obj) => _.some(F.hasIn(obj), keys)
 
 // Sets up basic event emitter/listener registry with an array of listeners per topic
 //  e.g. listeners: { topic1: [fn1, fn2, ...], topic2: [...], ... }

--- a/src/util/tree.js
+++ b/src/util/tree.js
@@ -16,3 +16,6 @@ export let bubbleUp = (f, path) => _.flow(F.prefixes, _.reverse, _.map(f))(path)
 
 let isNotEqual = _.negate(_.isEqual)
 export let isParent = _.overEvery([isNotEqual, _.startsWith])
+
+export let pathFromParents = (parents, node) =>
+  _.map('key', _.reverse([node, ...parents]))

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -328,23 +328,12 @@ describe('usage with mobx should generally work', () => {
     expect(tree.getNode(['root', 'filter 2'])).to.equal(tree.tree.children[1])
   })
   it('Test that pushing into an observable array converts array items to observables different from what was pushed', () => {
-    let tree = observable({
-      key: 'a',
-      children: [
-        {
-          key: 'b',
-        },
-      ],
-    })
-    let plainNode = {
-      key: 'c',
-    }
+    let tree = observable({ key: 'a', children: [{ key: 'b' }] })
+    let plainNode = { key: 'c' }
     tree.children.push(plainNode)
     expect(tree.children[1]).not.to.equal(plainNode)
 
-    let observableNode = {
-      key: 'd',
-    }
+    let observableNode = { key: 'd' }
     observableNode = observable(observableNode)
     tree.children.push(observableNode)
     expect(tree.children[2]).to.equal(observableNode)

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -67,6 +67,7 @@ describe('usage with mobx should generally work', () => {
     expect(dto).to.deep.equal({
       key: 'root',
       join: 'and',
+      lastUpdateTime: now,
       children: [
         {
           key: 'filter',

--- a/test/_mobx.js
+++ b/test/_mobx.js
@@ -13,7 +13,9 @@ const expect = chai.expect
 chai.use(sinonChai)
 
 let mobxAdapter = { snapshot: toJS, extend: set, initObject: observable }
-let ContextureMobx = x => ContextureClient({ ...mobxAdapter, ...x })
+let ContextureMobx = _.curry((x, y) =>
+  ContextureClient({ ...mobxAdapter, ...x })(y)
+)
 //,
 // F.updateOn('add', action),
 // F.updateOn('remove', action),
@@ -23,24 +25,16 @@ let ContextureMobx = x => ContextureClient({ ...mobxAdapter, ...x })
 
 let treeUtils = Tree
 
+let simplifyObject = _.flow(F.compactObject, _.omitBy(_.isFunction))
+
 describe('usage with mobx should generally work', () => {
   // TODO: make these generally self contained - some rely on previous test runs
   let tree = {
     key: 'root',
     join: 'and',
     children: [
-      {
-        key: 'filter',
-        type: 'facet',
-        values: [1, 2],
-      },
-      {
-        key: 'results',
-        type: 'results',
-        context: {
-          results: null,
-        },
-      },
+      { key: 'filter', type: 'facet', values: [1, 2] },
+      { key: 'results', type: 'results', context: { results: null } },
     ],
   }
   let responseData = {
@@ -50,21 +44,11 @@ describe('usage with mobx should generally work', () => {
         key: 'results',
         context: {
           count: 1,
-          results: [
-            {
-              title: 'Some result',
-            },
-            {
-              title: 'Some other result',
-            },
-          ],
+          results: [{ title: 'Some result' }, { title: 'Some other result' }],
         },
         size: 20,
       },
-      {
-        key: 'filter',
-        type: 'facet',
-      },
+      { key: 'filter', type: 'facet' },
     ],
   }
   let service = sinon.spy(() => responseData)
@@ -104,7 +88,7 @@ describe('usage with mobx should generally work', () => {
     expect(reactor).to.satisfy(x => x.callCount > 1)
     disposer()
     expect(
-      F.compactObject(treeUtils.lookup(['filter'], reactor.getCall(1).args[0]))
+      simplifyObject(treeUtils.lookup(['filter'], reactor.getCall(1).args[0]))
     ).to.deep.equal({
       key: 'filter',
       type: 'facet',
@@ -112,37 +96,20 @@ describe('usage with mobx should generally work', () => {
       hasValue: 1,
       mode: 'include',
       path: ['root', 'filter'],
-      context: {
-        options: [],
-        cardinality: null,
-      },
+      context: { options: [], cardinality: null },
       metaHistory: [],
     })
     // should update contexts
     expect(Tree.getNode(['root', 'results']).updating).to.be.false
     expect(toJS(Tree.getNode(['root', 'results']).context)).to.deep.equal({
       count: 1,
-      results: [
-        {
-          title: 'Some result',
-        },
-        {
-          title: 'Some other result',
-        },
-      ],
+      results: [{ title: 'Some result' }, { title: 'Some other result' }],
     })
     expect(
       treeUtils.lookup(['results'], reactor.lastCall.args[0]).context
     ).to.deep.equal({
       count: 1,
-      results: [
-        {
-          title: 'Some result',
-        },
-        {
-          title: 'Some other result',
-        },
-      ],
+      results: [{ title: 'Some result' }, { title: 'Some other result' }],
     })
   })
 
@@ -163,7 +130,7 @@ describe('usage with mobx should generally work', () => {
     expect(service).to.have.callCount(1)
     expect(reactor).to.satisfy(x => x.callCount > 1)
     expect(
-      F.compactObject(
+      simplifyObject(
         treeUtils.lookup(['newFilterWithValue'], reactor.getCall(2).args[0])
       )
     ).to.deep.equal({
@@ -172,10 +139,7 @@ describe('usage with mobx should generally work', () => {
       mode: 'include',
       values: 'asdf',
       path: ['root', 'newFilterWithValue'],
-      context: {
-        options: [],
-        cardinality: null,
-      },
+      context: { options: [], cardinality: null },
       metaHistory: [],
     })
     disposer()
@@ -219,7 +183,7 @@ describe('usage with mobx should generally work', () => {
     expect(reactor).to.satisfy(x => x.callCount > previousCallCount)
 
     expect(
-      F.compactObject(
+      simplifyObject(
         treeUtils.lookup(['newNotEmptyFilter'], reactor.getCall(0).args[0])
       )
     ).to.deep.equal({
@@ -234,7 +198,7 @@ describe('usage with mobx should generally work', () => {
     expect(
       _.flow(
         _.omit(['lastUpdateTime']),
-        F.compactObject
+        simplifyObject
       )(treeUtils.lookup(['newNotEmptyFilter'], reactor.getCall(1).args[0]))
     ).to.deep.equal({
       key: 'newNotEmptyFilter',
@@ -266,42 +230,25 @@ describe('usage with mobx should generally work', () => {
     service.resetHistory()
     let disposer = reaction(() => toJS(Tree.tree), reactor)
 
-    await Tree.mutate(['root', 'filter'], {
-      values: [1, 2, 3],
-    })
+    await Tree.mutate(['root', 'filter'], { values: [1, 2, 3] })
     expect(service).to.have.callCount(1)
     expect(
       _.flow(
         _.get(['context', 'results']),
         _.toArray
       )(Tree.getNode(['root', 'results']))
-    ).to.deep.equal([
-      {
-        title: 'Some result',
-      },
-      {
-        title: 'Some other result',
-      },
-    ])
+    ).to.deep.equal([{ title: 'Some result' }, { title: 'Some other result' }])
     treeUtils.lookup(['results'], responseData).context.results = [
-      {
-        title: 'New values',
-      },
+      { title: 'New values' },
     ]
-    await Tree.mutate(['root', 'filter'], {
-      values: [1, 2, 3, 4],
-    })
+    await Tree.mutate(['root', 'filter'], { values: [1, 2, 3, 4] })
     expect(service).to.have.callCount(2)
     expect(
       _.flow(
         _.get(['context', 'results']),
         _.toArray
       )(Tree.getNode(['root', 'results']))
-    ).to.deep.equal([
-      {
-        title: 'New values',
-      },
-    ])
+    ).to.deep.equal([{ title: 'New values' }])
     disposer()
   })
 
@@ -316,21 +263,9 @@ describe('usage with mobx should generally work', () => {
       key: 'root',
       join: 'and',
       children: [
-        {
-          key: 'results',
-          type: 'results',
-          page: 1,
-        },
-        {
-          key: 'agencies',
-          field: 'Organization.Name',
-          type: 'facet',
-        },
-        {
-          key: 'vendors',
-          field: 'Vendor.Name',
-          type: 'facet',
-        },
+        { key: 'results', type: 'results', page: 1 },
+        { key: 'agencies', field: 'Organization.Name', type: 'facet' },
+        { key: 'vendors', field: 'Vendor.Name', type: 'facet' },
       ],
     })
     // Get the results node instead of passing an array in to test case where dispatched path is an observable array
@@ -350,11 +285,7 @@ describe('usage with mobx should generally work', () => {
       key: 'root',
       join: 'and',
       children: [
-        {
-          key: 'results',
-          type: 'results',
-          page: 1,
-        },
+        { key: 'results', type: 'results', page: 1 },
         {
           key: 'subgroup',
           type: 'group',

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,7 @@ let AllTests = ContextureClient => {
       expect(dto).to.deep.equal({
         key: 'root',
         join: 'and',
+        lastUpdateTime: now,
         children: [
           {
             key: 'filter',
@@ -283,6 +284,7 @@ let AllTests = ContextureClient => {
     expect(dto).to.deep.equal({
       key: 'root',
       join: 'and',
+      lastUpdateTime: now,
       children: [
         {
           key: 'analysis',
@@ -800,6 +802,7 @@ let AllTests = ContextureClient => {
     expect(dto).to.deep.equal({
       key: 'root',
       join: 'and',
+      lastUpdateTime: now,
       children: [
         {
           key: 'a',

--- a/test/index.js
+++ b/test/index.js
@@ -2384,25 +2384,25 @@ let AllTests = ContextureClient => {
       }
     )
     let action = tree.mutate(['root', 'filter'], { values: ['other Value'] })
-    
+
     // Before async validate runs on dispatch ( and thus before marking for update)
     expect(!!tree.getNode(['root', 'results']).isStale).to.be.false
     expect(!!tree.getNode(['root']).isStale).to.be.false
-    
+
     // Preparing to search (0 ms delay because validate is async)
     await Promise.delay()
     expect(tree.getNode(['root', 'results']).isStale).to.be.true
     expect(tree.getNode(['root']).markedForUpdate).to.be.true
     expect(tree.getNode(['root']).isStale).to.be.true
     expect(!!tree.getNode(['root']).updating).to.be.false
-    
+
     // Prepare for search, but run before search finishes
     /// TODOOO HERE:::: unpredicable fail - could be timing issue???
     await Promise.delay(5)
     expect(tree.getNode(['root']).markedForUpdate).to.be.false
     expect(tree.getNode(['root']).isStale).to.be.true
     expect(tree.getNode(['root']).updating).to.be.true
-    
+
     // After search finishes
     await action
     expect(tree.getNode(['root']).markedForUpdate).to.be.false

--- a/test/index.js
+++ b/test/index.js
@@ -2346,6 +2346,22 @@ let AllTests = ContextureClient => {
     // resultWatcher called twice more because facet change resets page to 0
     expect(resultWatcher).to.have.callCount(6)
   })
+  it('should getNode', async () => {
+    let service = sinon.spy(mockService())
+    let Tree = ContextureClient(
+      { service, debounce: 1 },
+      {
+        key: 'root',
+        join: 'and',
+        children: [
+          { key: 'results', type: 'results', infiniteScroll: true },
+          { key: 'test', type: 'facet', values: [] },
+        ],
+      }
+    )
+    let result = Tree.getNode(['root', 'results'])
+    expect(result.infiniteScroll).to.be.true
+  })
 }
 
 describe('lib', () => AllTests(ContextureClient))

--- a/test/listeners.js
+++ b/test/listeners.js
@@ -69,6 +69,60 @@ let AllTests = ContextureClient => {
       expect(filterWatcher).to.have.callCount(4) // mark for update, updating, results, not updating
       expect(resultWatcher).to.have.callCount(9)
     })
+    it('watchNode with keys', async () => {
+      let service = sinon.spy(mockService({ delay: 10 }))
+      let tree = ContextureClient(
+        { service, debounce: 1 },
+        {
+          key: 'root',
+          join: 'and',
+          children: [
+            {
+              key: 'filter',
+              type: 'facet',
+              field: 'facetfield',
+              values: ['some value'],
+            },
+            { key: 'results', type: 'results' },
+          ],
+        }
+      )
+      let filterDom = ''
+      let resultsDom = ''
+      let filterWatcher = sinon.spy(node => {
+        filterDom = `<div>
+  <h1>Facet</h1>
+  <b>Field: ${node.field}</>
+  values: ${_.join(', ', node.values)}
+</div>`
+      })
+      let resultWatcher = sinon.spy((node, delta) => {
+        resultsDom = `<table>${_.map(
+          result =>
+            `\n<tr>${_.map(val => `<td>${val}</td>`, _.values(result))}</tr>`,
+          node.context.results
+        )}
+</table>`
+      })
+      tree.watchNode(['root', 'filter'], filterWatcher, ['field', 'values'])
+      tree.watchNode(['root', 'results'], resultWatcher, ['context.results'])
+      expect(filterDom).to.equal('')
+      let action = tree.mutate(['root', 'filter'], { values: ['other Value'] })
+      expect(filterDom).to.equal(`<div>
+  <h1>Facet</h1>
+  <b>Field: facetfield</>
+  values: other Value
+</div>`)
+      expect(resultsDom).to.equal('') // hasn't run yet
+      await action
+
+      expect(resultsDom).to.equal(`<table>
+<tr><td>some result</td></tr>
+</table>`)
+
+      expect(filterWatcher).to.have.callCount(1) // mark for update, updating, results, not updating
+      expect(resultWatcher).to.have.callCount(1)
+    })
   })
 }
 

--- a/test/listeners.js
+++ b/test/listeners.js
@@ -1,0 +1,76 @@
+import _ from 'lodash/fp'
+import chai from 'chai'
+import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import ContextureClient from '../src'
+import mockService from '../src/mockService'
+import { observable, toJS, set } from 'mobx'
+const expect = chai.expect
+chai.use(sinonChai)
+
+let mobxAdapter = { snapshot: toJS, extend: set, initObject: observable }
+let ContextureMobx = _.curry((x, y) =>
+  ContextureClient({ ...mobxAdapter, ...x })(y)
+)
+
+let AllTests = ContextureClient => {
+  describe('listeners', () => {
+    it('watchNode', async () => {
+      let service = sinon.spy(mockService({ delay: 10 }))
+      let tree = ContextureClient(
+        { service, debounce: 1 },
+        {
+          key: 'root',
+          join: 'and',
+          children: [
+            {
+              key: 'filter',
+              type: 'facet',
+              field: 'facetfield',
+              values: ['some value'],
+            },
+            { key: 'results', type: 'results' },
+          ],
+        }
+      )
+      let filterDom = ''
+      let resultsDom = ''
+      let filterWatcher = sinon.spy(node => {
+        filterDom = `<div>
+  <h1>Facet</h1>
+  <b>Field: ${node.field}</>
+  values: ${_.join(', ', node.values)}
+</div>`
+      })
+      let resultWatcher = sinon.spy((node, delta) => {
+        resultsDom = `<table>${_.map(
+          result =>
+            `\n<tr>${_.map(val => `<td>${val}</td>`, _.values(result))}</tr>`,
+          node.context.results
+        )}
+</table>`
+      })
+      tree.watchNode(['root', 'filter'], filterWatcher)
+      tree.watchNode(['root', 'results'], resultWatcher)
+      expect(filterDom).to.equal('')
+      let action = tree.mutate(['root', 'filter'], { values: ['other Value'] })
+      expect(filterDom).to.equal(`<div>
+  <h1>Facet</h1>
+  <b>Field: facetfield</>
+  values: other Value
+</div>`)
+      expect(resultsDom).to.equal(`<table>\n</table>`)
+      await action
+
+      expect(resultsDom).to.equal(`<table>
+<tr><td>some result</td></tr>
+</table>`)
+
+      expect(filterWatcher).to.have.callCount(4) // mark for update, updating, results, not updating
+      expect(resultWatcher).to.have.callCount(9)
+    })
+  })
+}
+
+describe('lib', () => AllTests(ContextureClient))
+describe('mobx', () => AllTests(ContextureMobx))

--- a/test/listeners.js
+++ b/test/listeners.js
@@ -42,7 +42,7 @@ let AllTests = ContextureClient => {
   values: ${_.join(', ', node.values)}
 </div>`
       })
-      let resultWatcher = sinon.spy((node, delta) => {
+      let resultWatcher = sinon.spy(node => {
         resultsDom = `<table>${_.map(
           result =>
             `\n<tr>${_.map(val => `<td>${val}</td>`, _.values(result))}</tr>`,
@@ -96,7 +96,7 @@ let AllTests = ContextureClient => {
   values: ${_.join(', ', node.values)}
 </div>`
       })
-      let resultWatcher = sinon.spy((node, delta) => {
+      let resultWatcher = sinon.spy(node => {
         resultsDom = `<table>${_.map(
           result =>
             `\n<tr>${_.map(val => `<td>${val}</td>`, _.values(result))}</tr>`,

--- a/test/listeners.js
+++ b/test/listeners.js
@@ -123,6 +123,46 @@ let AllTests = ContextureClient => {
       expect(filterWatcher).to.have.callCount(1) // mark for update, updating, results, not updating
       expect(resultWatcher).to.have.callCount(1)
     })
+    it('watchNode on children', async () => {
+      let service = sinon.spy(mockService({ delay: 10 }))
+      let tree = ContextureClient(
+        { service, debounce: 1 },
+        {
+          key: 'root',
+          join: 'and',
+          children: [
+            {
+              key: 'criteria',
+              join: 'and',
+              children: [
+                {
+                  key: 'filter',
+                  type: 'facet',
+                  field: 'facetfield',
+                  values: ['some value'],
+                },
+              ],
+            },
+            { key: 'results', type: 'results' },
+          ],
+        }
+      )
+      let criteriaKeys = []
+      tree.watchNode(
+        ['root', 'criteria'],
+        node => {
+          criteriaKeys = _.map('key', node.children)
+        },
+        ['children']
+      )
+      tree.add(['root', 'criteria'], {
+        key: 'newFilter',
+        type: 'facet',
+        field: 'facetfield2',
+        values: ['otherValues'],
+      })
+      expect(criteriaKeys).to.deep.eq(['filter', 'newFilter'])
+    })
   })
 }
 


### PR DESCRIPTION
Removes internal dependency on the flat tree representation. Fixes #131.

Before merging, we should have an answer for #90 so that we can eliminate the only known external (albeit undocumented) use of the flat tree so we can rip it out entirely.

TODO: we might want to `_.memoize` `getNode` and clear the cache in mutating actions. That would preserve the flat tree's performance, but might not be worth the complexity.