### PR TITLE
Pivot node: deprecating subtotals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.45.0
+* Pivot node: removing subtotals flag as it was deprecated in ES
+
 # 2.44.0
 * Add `isStale`, sugar for `markedForUpdate || updating`
 * Node flags `isStale`, `markedForUpdate`, and `updating` are now properly set at the group level as whether any of their children have them set

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -282,7 +282,6 @@ export default F.stampKey('type', {
       filters: 'others',
       sort: 'self',
       flatten: 'self',
-      subtotals: 'self',
     },
     defaults: {
       columns: [],
@@ -293,7 +292,6 @@ export default F.stampKey('type', {
       drilldown: null,
       showCounts: false,
       flatten: false,
-      subtotals: false,
       context: {
         results: [],
       },


### PR DESCRIPTION
* [x] Pivot node: removing defaults and reactors for subtotals flag is it's deprecated
