### PR TITLE
fix: reset the drilldown on tree mutations

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 16.15.0
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 16.15.0
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.45.1
+* Pivot node: reset the drilldown on tree mutations
+
 # 2.45.0
 * Pivot node: removing subtotals flag as it was deprecated in ES
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.44.0",
+  "version": "2.45.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.45.0",
+  "version": "2.45.1",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -304,7 +304,7 @@ export default F.stampKey('type', {
         // Resetting the drilldown when the node is changed
         // allows to return expected root results instead of nested drilldown
         // EX: changing the columns or rows config was not returning the new results
-        if (node.drilldown && !value.drilldown) {
+        if (node.drilldown && !_.has('drilldown', value)) {
           extend(node, { drilldown: [] })
         }
         F.mapIndexed((group, i) => {

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -298,8 +298,15 @@ export default F.stampKey('type', {
     },
     onDispatch(event, extend) {
       // If mutating any group type specific "resetting" keys, set `forceReplaceResponse`
-      let { type, node, previous } = event
+      let { type, node, previous, value } = event
+
       if (type === 'mutate') {
+        // Resetting the drilldown when the node is changed
+        // allows to return expected root results instead of nested drilldown
+        // EX: changing the columns or rows config was not returning the new results
+        if (node.drilldown && !value.drilldown) {
+          extend(node, { drilldown: [] })
+        }
         F.mapIndexed((group, i) => {
           let previousGroup = previous.groups[i]
           let type = group.type
@@ -311,6 +318,12 @@ export default F.stampKey('type', {
             extend(node, { forceReplaceResponse: true })
         }, node.groups)
       }
+    },
+    // Resetting the drilldown when the tree is changed
+    // allows to return expected root results instead of nested drilldown
+    // EX: criteria filters didn't work properly when drilldown was applied
+    onUpdateByOthers(node, extend) {
+      if (node.drilldown) extend(node, { drilldown: [] })
     },
     shouldMergeResponse: node => !_.isEmpty(node.drilldown),
     mergeResponse(node, response, extend, snapshot) {


### PR DESCRIPTION
Resetting the drilldown when the pivot node or tree is changed allows to return expected root results instead of nested drilldown results.

EX: criteria filters didn't work properly when drilldown was applied or changing the columns or rows config was not returning the new results