### PR TITLE
Add per-node onSerialize hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.48.0
+* New feature: new per-node hook `onSerialize` allows users to customize tree nodes as the tree is being serialized
+
 # 2.47.0
 * Pivot node: new `pagination` logic with `drilldown` and `skip`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contexture-client",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contexture-client",
-      "version": "2.47.0",
+      "version": "2.48.0",
       "license": "MIT",
       "dependencies": {
         "futil": "^1.70.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "contexture-client",
-      "version": "2.39.1",
+      "version": "2.47.0",
       "license": "MIT",
       "dependencies": {
-        "futil": "^1.69.0",
+        "futil": "^1.70.0",
         "lodash": "^4.17.15"
       },
       "devDependencies": {
@@ -4683,9 +4683,9 @@
       "dev": true
     },
     "node_modules/futil": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/futil/-/futil-1.69.0.tgz",
-      "integrity": "sha512-7UHnHv5yKfqfd5zZAjvVmVW9AkUW4d3oGDDwc4b/6WZWFB14uh5QRoHFBhisiwWWmGCMCTkUxh3ndQPr2ZTU7Q==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/futil/-/futil-1.70.0.tgz",
+      "integrity": "sha512-oGa1e5c3DiDPeJ2upL1AVXQaxRdGtIl8wM0zBqxtg9JjZW96DMYL09+W+j1Kd9yowAZ2hCsfIdeUtUG6qzxgMQ==",
       "dependencies": {
         "babel-polyfill": "^6.23.0",
         "lodash": "^4.17.4"
@@ -17974,9 +17974,9 @@
       "dev": true
     },
     "futil": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/futil/-/futil-1.69.0.tgz",
-      "integrity": "sha512-7UHnHv5yKfqfd5zZAjvVmVW9AkUW4d3oGDDwc4b/6WZWFB14uh5QRoHFBhisiwWWmGCMCTkUxh3ndQPr2ZTU7Q==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/futil/-/futil-1.70.0.tgz",
+      "integrity": "sha512-oGa1e5c3DiDPeJ2upL1AVXQaxRdGtIl8wM0zBqxtg9JjZW96DMYL09+W+j1Kd9yowAZ2hCsfIdeUtUG6qzxgMQ==",
       "requires": {
         "babel-polyfill": "^6.23.0",
         "lodash": "^4.17.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/smartprocure/contexture-client#readme",
   "dependencies": {
-    "futil": "^1.69.0",
+    "futil": "^1.70.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ export let ContextTree = _.curry(
       let node = getNode(path)
 
       markLastUpdate(now)(node || tree)
-      let body = serialize(snapshot(tree), { search: true })
+      let body = serialize(snapshot(tree), types, { search: true })
       prepForUpdate(node || tree)
 
       // make all other nodes filter only
@@ -257,7 +257,8 @@ export let ContextTree = _.curry(
     }
 
     let TreeInstance = initObject({
-      serialize: path => serialize(snapshot(path ? getNode(path) : tree), {}),
+      serialize: path =>
+        serialize(snapshot(path ? getNode(path) : tree), types, {}),
       tree,
       debugInfo,
       ...actionProps,

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,20 +1,30 @@
 import _ from 'lodash/fp'
-import { when } from 'futil-js'
+import F from 'futil-js'
 import { Tree } from './util/tree'
 import { internalStateKeys } from './node'
+import { runTypeFunctionOrDefault } from './types'
 
 let isFilterOnly = x => !x.children && (x.forceFilterOnly || !x.markedForUpdate)
+
 let getNilKeys = _.flow(_.pickBy(_.isNil), _.keys)
 
-export default (tree, { search } = {}) =>
-  Tree.map(({ onSerialize = _.identity, ...x }) => {
-    let omitKeys = [
-      ..._.without(search && ['lastUpdateTime'], internalStateKeys),
-      ...getNilKeys(x),
-    ]
-    return _.flow(
-      when(x => search && isFilterOnly(x), _.set('filterOnly', true)),
-      _.omit(omitKeys),
+export default (tree, types, { search } = {}) => {
+  let onSerialize = node =>
+    runTypeFunctionOrDefault(_.identity, types, 'onSerialize', node, {})
+
+  let internalKeys = _.without(search && ['lastUpdateTime'], internalStateKeys)
+
+  let setFilterOnly = F.when(
+    node => search && isFilterOnly(node),
+    _.set('filterOnly', true)
+  )
+
+  return Tree.map(
+    _.flow(
+      setFilterOnly,
+      x => _.omit([...internalKeys, ...getNilKeys(x)], x),
       onSerialize
-    )(x)
-  }, tree)
+    ),
+    tree
+  )
+}

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,37 @@ let AllTests = ContextureClient => {
     }
     let service = sinon.spy(mockService())
     let Tree = ContextureClient({ service, debounce: 1 }, tree)
+
+    it('should support per-node onSerialize hook', () => {
+      let types = _.merge(exampleTypes, {
+        results: {
+          onSerialize: _.flow(
+            _.set('customKey', 'customValue'),
+            _.unset('pageSize')
+          ),
+        },
+      })
+      let Tree = ContextureClient({ service, debounce: 0, types }, tree)
+      expect(Tree.serialize()).to.deep.equal({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'filter',
+            type: 'facet',
+            mode: 'include',
+            values: [],
+            optionsFilter: '',
+          },
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+            customKey: 'customValue',
+          },
+        ],
+      })
+    })
     it('should generally mutate', async () => {
       await Tree.mutate(['root', 'filter'], {
         values: ['a'],
@@ -96,31 +127,6 @@ let AllTests = ContextureClient => {
             type: 'results',
             page: 1,
             pageSize: 10,
-          },
-        ],
-      })
-    })
-    it('should support per-node onSerialize hook', () => {
-      Tree.tree.children[1].onSerialize = _.flow(
-        _.set('customKey', 'customValue'),
-        _.unset('pageSize')
-      )
-      expect(Tree.serialize()).to.deep.equal({
-        key: 'root',
-        join: 'and',
-        children: [
-          {
-            key: 'filter',
-            type: 'facet',
-            mode: 'include',
-            values: ['a'],
-            optionsFilter: '',
-          },
-          {
-            key: 'results',
-            type: 'results',
-            page: 1,
-            customKey: 'customValue',
           },
         ],
       })

--- a/test/index.js
+++ b/test/index.js
@@ -100,6 +100,31 @@ let AllTests = ContextureClient => {
         ],
       })
     })
+    it('should support per-node onSerialize hook', () => {
+      Tree.tree.children[1].onSerialize = _.flow(
+        _.set('customKey', 'customValue'),
+        _.unset('pageSize')
+      )
+      expect(Tree.serialize()).to.deep.equal({
+        key: 'root',
+        join: 'and',
+        children: [
+          {
+            key: 'filter',
+            type: 'facet',
+            mode: 'include',
+            values: ['a'],
+            optionsFilter: '',
+          },
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+            customKey: 'customValue',
+          },
+        ],
+      })
+    })
     it('should not block blank searches', async () => {
       service.resetHistory()
       await Tree.mutate(['root', 'filter'], {


### PR DESCRIPTION
New feature: new per-node hook `onSerialize` allows users to customize tree nodes as the tree is being serialized.