### PR TITLE
Pivot node changes to support selectedRows recompute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.49.2
-* Pivot node: Add new field `selectedRowsKeys`. Clear as needed `selectedRowsKeys` when the `expansions` array and/or query results are changing 
+* Pivot node: Add new field `selectedRows`. Clear as needed `selectedRows` when the `expansions` array and/or query results are changing 
 
 # 2.49.1
 * Pivot node: fixing issues with sorting and result merging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.49.2
+* Pivot node: Add new field `selectedRowsKeys`. Clear as needed `selectedRowsKeys` when the `expansions` array and/or query results are changing 
+
 # 2.49.1
 * Pivot node: fixing issues with sorting and result merging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contexture-client",
-  "version": "2.49.1",
+  "version": "2.49.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contexture-client",
-      "version": "2.49.1",
+      "version": "2.49.2",
       "license": "MIT",
       "dependencies": {
         "futil": "^1.70.0",
@@ -19407,8 +19407,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
@@ -19737,8 +19736,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
@@ -21733,8 +21731,7 @@
       "version": "21.27.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.27.2.tgz",
       "integrity": "sha512-0E4OIgBJVlAmf1KfYFtZ3gYxgUzC5Eb3Jzmrc9ikI1OY+/cM8Kh72Ti7KfpeHNeD3HJNf9SmEfmvQLIz44Hrhw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-lodash": {
       "version": "2.7.0",
@@ -23982,8 +23979,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.0.0",
@@ -26790,8 +26786,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
@@ -28293,8 +28288,7 @@
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
           "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.49.1",
+  "version": "2.49.2",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes/pivot.js
+++ b/src/exampleTypes/pivot.js
@@ -52,13 +52,13 @@ let mergeResults = _.mergeWith((current, additional, prop) => {
 })
 
 let maybeRemoveSelectedRows = (extend, node) => {
-  let selectedRowKeys = _.filter(rowPath => {
+  let selectedRows = _.filter(rowPath => {
     let expansion = { type: 'rows', drilldown: _.initial(toJS(rowPath)) }
     let parentRowLoadedKeys = previouslyLoadedKeys(expansion, node.expansions)
     return _.includes(_.last(rowPath), parentRowLoadedKeys)
-  }, node.selectedRowKeys)
+  }, node.selectedRows)
 
-  extend(node, { selectedRowKeys })
+  extend(node, { selectedRows })
 }
 
 // Resetting the expansions when the pivot node is changed
@@ -203,7 +203,7 @@ export default {
     context: {
       results: {},
     },
-    selectedRowKeys: [],
+    selectedRows: [],
   },
   onDispatch(event, extend) {
     let { type, node, value } = event
@@ -214,7 +214,7 @@ export default {
     if (_.has('sort', value)) return resetExpandedRows(extend, node)
 
     // if expansions or selected row change, do not reset expansions
-    if (F.cascade(['expansions', 'selectedRowKeys'], value)) return
+    if (F.cascade(['expansions', 'selectedRows'], value)) return
 
     // if anything else about node configuration is changed resetting expansions
     resetExpansions(extend, node)

--- a/src/exampleTypes/pivot.js
+++ b/src/exampleTypes/pivot.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import F from 'futil'
 import { toJS } from 'mobx'
 
 let getKey = x => x.keyAsString || x.key
@@ -14,8 +15,10 @@ let resultsForDrilldown = (type, drilldown, results) => {
   return resultsForDrilldown(type, drilldown.slice(1), match)
 }
 
-let previouslyLoadedKeys = (expansion, expansions) =>
-  _.flow(
+let previouslyLoadedKeys = (expansion, expansions) => {
+  expansion = toJS(expansion)
+  return _.flow(
+    toJS,
     _.filter(
       ({ type, drilldown, loaded }) =>
         type === expansion.type &&
@@ -24,6 +27,7 @@ let previouslyLoadedKeys = (expansion, expansions) =>
     ),
     _.flatMap('loaded')
   )(expansions)
+}
 
 let getResultKeys = (expansion, node, results) => {
   let groupType = expansion.type
@@ -47,6 +51,16 @@ let mergeResults = _.mergeWith((current, additional, prop) => {
   } else if (_.isArray(additional)) return additional
 })
 
+let maybeRemoveSelectedRows = (extend, node) => {
+  let selectedRowKeys = _.filter(rowPath => {
+    let expansion = { type: 'rows', drilldown: _.initial(toJS(rowPath)) }
+    let parentRowLoadedKeys = previouslyLoadedKeys(expansion, node.expansions)
+    return _.includes(_.last(rowPath), parentRowLoadedKeys)
+  }, node.selectedRowKeys)
+
+  extend(node, { selectedRowKeys })
+}
+
 // Resetting the expansions when the pivot node is changed
 // allows to return expected root results instead of merging result
 // EX: changing the columns or rows config was not returning the new results
@@ -54,6 +68,8 @@ let resetExpansions = (extend, node) => {
   extend(node, {
     expansions: [],
   })
+  // reset selected rows as well, since that is very much dependent on the expansions array
+  maybeRemoveSelectedRows(extend, node)
 }
 
 // Resetting the row expansions and columns loaded when the sorting is changed
@@ -122,6 +138,10 @@ let collapse = (tree, path, type, drilldown) => {
       )
   )(node.expansions)
 
+  if (type === 'rows') {
+    maybeRemoveSelectedRows(tree.extend, node)
+  }
+
   // removing collapsed rows or columns from results
   drilldownResults[type] = undefined
   // triggering observer update
@@ -183,6 +203,7 @@ export default {
     context: {
       results: {},
     },
+    selectedRowKeys: [],
   },
   onDispatch(event, extend) {
     let { type, node, value } = event
@@ -192,10 +213,10 @@ export default {
     // if sorting is changed we are preserving expanded columns
     if (_.has('sort', value)) return resetExpandedRows(extend, node)
 
-    if (_.has('expansions', value)) return
+    // if expansions or selected row change, do not reset expansions
+    if (F.cascade(['expansions', 'selectedRowKeys'], value)) return
 
     // if anything else about node configuration is changed resetting expansions
-
     resetExpansions(extend, node)
   },
   // Resetting the expansions when the tree is changed
@@ -226,5 +247,7 @@ export default {
 
     // Write on the node
     extend(node, { context })
+    // remove selected rows that are no longer part of the result
+    maybeRemoveSelectedRows(extend, node)
   },
 }


### PR DESCRIPTION
- Add new field `selectedRows`. Modify/Clear as needed `selectedRows` when the `expansions` array and/or query results are changing