### PR TITLE
Do not remove root node when present in `selectedRows`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.49.4
+* Pivot node: Do not remove root node when present in `selectedRows` when checking which selected rows should remain 
+
 # 2.49.3
 * Pivot node: Do not reset expansions when the filters are changed (that only affects other nodes)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contexture-client",
-  "version": "2.49.3",
+  "version": "2.49.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contexture-client",
-      "version": "2.49.3",
+      "version": "2.49.4",
       "license": "MIT",
       "dependencies": {
         "futil": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.49.3",
+  "version": "2.49.4",
   "description": "The Contexture (aka ContextTree) Client",
   "main": "lib/contexture-client.js",
   "scripts": {

--- a/src/exampleTypes/pivot.js
+++ b/src/exampleTypes/pivot.js
@@ -55,7 +55,9 @@ let maybeRemoveSelectedRows = (extend, node) => {
   let selectedRows = _.filter(rowPath => {
     let expansion = { type: 'rows', drilldown: _.initial(toJS(rowPath)) }
     let parentRowLoadedKeys = previouslyLoadedKeys(expansion, node.expansions)
-    return _.includes(_.last(rowPath), parentRowLoadedKeys)
+    return (
+      _.isEmpty(rowPath) || _.includes(_.last(rowPath), parentRowLoadedKeys)
+    )
   }, node.selectedRows)
 
   extend(node, { selectedRows })


### PR DESCRIPTION
when checking which selected rows should remain