### PR TITLE
Revert package.json exports field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.49.8
+
+- Revert package.json exports field
+
 # 2.49.7
 
 - Misc fixes and cleanup

--- a/package.json
+++ b/package.json
@@ -1,15 +1,9 @@
 {
   "name": "contexture-client",
-  "version": "2.49.7",
+  "version": "2.49.8",
   "description": "The Contexture (aka ContextTree) Client",
   "type": "module",
-  "main": "dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    }
-  },
+  "main": "dist/esm/index.js",
   "files": [
     "./dist"
   ],


### PR DESCRIPTION
We're importing from `dist` in quite a few places (which we shouldn't do) and the files do not get resolved by node because of the `exports` field. Proper fix is to re-export everything we need.