### PR TITLE
Add exports field to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.49.10
+
+- Bring back package.json exports field
+
 # 2.49.9
 
 - Pivot node: Do not reset expansions on pause mutations

--- a/package.json
+++ b/package.json
@@ -1,9 +1,18 @@
 {
   "name": "contexture-client",
-  "version": "2.49.9",
+  "version": "2.49.10",
   "description": "The Contexture (aka ContextTree) Client",
   "type": "module",
-  "main": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./*": {
+      "import": "./dist/esm/*",
+      "require": "./dist/cjs/*"
+    }
+  },
   "files": [
     "./dist"
   ],


### PR DESCRIPTION
This is what nodejs uses to decide which files of the package to use (https://nodejs.org/api/packages.html#subpath-exports). Now any of these will work in the node repl! 🤯 

```javascript
let cjs_client = require('contexture-client')
let esm_client = await import('contexture-client')
let cjs_pivot = require('contexture-client/exampleTypes/pivot.js')
let esm_pivot = await import('contexture-client/exampleTypes/pivot.js')
```