### PR TITLE
Attempt to fix default exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.49.11
+
+- Fix default exports when library is being consumed from CommonJS. More info at https://esbuild.github.io/content-types/#default-interop
+
 # 2.49.10
 
 - Bring back package.json exports field

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-client",
-  "version": "2.49.10",
+  "version": "2.49.11",
   "description": "The Contexture (aka ContextTree) Client",
   "type": "module",
   "exports": {
@@ -40,6 +40,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
+    "@flex-development/toggle-pkg-type": "^1.0.1",
     "danger": "^11.1.2",
     "danger-plugin-coverage": "^1.6.2",
     "duti": "^0.15.2",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,8 @@
 import fs from 'fs/promises'
 import glob from 'glob'
 import esbuild from 'esbuild'
+// https://github.com/flex-development/toggle-pkg-type#when-should-i-use-this
+import toggleTypeModule from '@flex-development/toggle-pkg-type'
 
 // Clear build directory since esbuild won't do it for us
 await fs.rm('dist', { force: true, recursive: true })
@@ -16,8 +18,10 @@ let entryPoints = glob.sync('src/**/*.js', {
 
 // Build project
 
+toggleTypeModule('off')
+
 await esbuild.build({
-  platform: 'node',
+  platform: 'browser',
   format: 'cjs',
   target: 'es2022',
   outdir: 'dist/cjs',
@@ -25,6 +29,8 @@ await esbuild.build({
 })
 
 await fs.writeFile('./dist/cjs/package.json', '{ "type": "commonjs" }')
+
+toggleTypeModule('on')
 
 await esbuild.build({
   platform: 'browser',

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@flex-development/toggle-pkg-type@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@flex-development/toggle-pkg-type@npm:1.0.1"
+  bin:
+    toggle-pkg-type: dist/cli.mjs
+  checksum: 6f1a3e73d707e57a06c240ff8172c741275ed388407528eba2f70ba9dff62907ae0d5efe4544ee3a09994b397125efb1392350023fa83e44411bcab48835da1d
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -2252,6 +2261,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "contexture-client@workspace:."
   dependencies:
+    "@flex-development/toggle-pkg-type": ^1.0.1
     danger: ^11.1.2
     danger-plugin-coverage: ^1.6.2
     duti: ^0.15.2


### PR DESCRIPTION
When an ESM package is transpiled to CJS, default exports are wrapped in `default`, g.g. `export default foo` will need to be imported as `let foo = require('library').default` instead of `let foo = require('library')`.

This is very annoying as I don't want to change all our default exports to be named (although we should do this anyway to avoid these kinds of issues). In the meantime, we can work around this by using https://github.com/flex-development/toggle-pkg-type#when-should-i-use-this, which is specific to esbuild.

Here's a more detailed explanation on the issue: https://esbuild.github.io/content-types/#default-interop